### PR TITLE
Updates to the DDL for Vocabulary Version Column Length

### DIFF
--- a/Oracle/OMOP CDM ddl - Oracle.sql
+++ b/Oracle/OMOP CDM ddl - Oracle.sql
@@ -28,10 +28,12 @@
 
 script to create OMOP common data model, version 5.0 for Oracle database
 
-last revised: 12 Oct 2014
+last revised: 20 NOV 2014
 
 author:  Patrick Ryan
 
+Update to cdm_source table column vocabulary_version from VARCHAR(20) to VARCHAR(255), 
+to align with the vocabulary table vocabulary_name length - CD
 
 *************************/
 

--- a/PostgreSQL/OMOP CDM ddl - PostgreSQL.sql
+++ b/PostgreSQL/OMOP CDM ddl - PostgreSQL.sql
@@ -28,10 +28,12 @@
 
 script to create OMOP common data model, version 5.0 for PostgreSQL database
 
-last revised: 12 Oct 2014
+last revised: 20 NOV 2014
 
 author:  Patrick Ryan
 
+Updatd cdm_source table column entry vocabulary_version from VARCHAR(20) to VARCHAR(255), subsequently aligning 
+with the vocabulary table vocabulary_name column
 
 *************************/
 
@@ -203,7 +205,7 @@ CREATE TABLE cdm_source
 	 source_release_date				DATE			NULL,
 	 cdm_release_date					DATE			NULL,
 	 cdm_version						VARCHAR(10)		NULL,
-	 vocabulary_version					VARCHAR(20)		NULL
+	 vocabulary_version					VARCHAR(255)		NULL
     ) 
 ;
 

--- a/Sql Server/OMOP CDM ddl - SQL Server.sql
+++ b/Sql Server/OMOP CDM ddl - SQL Server.sql
@@ -28,10 +28,12 @@
 
 script to create OMOP common data model, version 5.0 for SQL Server database
 
-last revised: 12 Oct 2014
+last revised: 20 NOV 2014
 
 author:  Patrick Ryan
 
+Updated cdm_source table column vocabulary_version from VARCHAR(20) to VARCHAR(255),
+subsequently aligning with the vocabulary table and vocabulary_name length- CD 
 
 *************************/
 
@@ -203,7 +205,7 @@ CREATE TABLE cdm_source
 	 source_release_date				DATE			NULL,
 	 cdm_release_date					DATE			NULL,
 	 cdm_version						VARCHAR(10)		NULL,
-	 vocabulary_version					VARCHAR(20)		NULL
+	 vocabulary_version					VARCHAR(255)		NULL
     ) 
 ;
 


### PR DESCRIPTION
Updates to the DDL files for the PostgresSQL, SQL Server and Oracle database.

Table:
cdm_source

Column
vocabulary_version from VARCHAR(20) to VARCHAR(255)

Reason:
Insufficient space to handle whole vocabulary version nomenclature, plus mismatch in column lengths from the vocabulary_name column in the table vocabulary.
