### PR TITLE
Add latest_update to VOCABULARY ddl

### DIFF
--- a/Sql Server/OMOP CDM ddl - SQL Server.sql
+++ b/Sql Server/OMOP CDM ddl - SQL Server.sql
@@ -65,7 +65,8 @@ CREATE TABLE vocabulary (
   vocabulary_name		VARCHAR(255)	NOT NULL,
   vocabulary_reference	VARCHAR(255)	NULL,
   vocabulary_version	VARCHAR(255)	NULL,
-  vocabulary_concept_id	INTEGER			NOT NULL
+  vocabulary_concept_id	INTEGER			NOT NULL,
+  latest_update			DATE			NULL
 )
 ;
 


### PR DESCRIPTION
In vocabulary_5.0_20150320 update there is a LATEST_UPDATE column in VOCABULARY table both in the source file and load script, but it is missing in DDL script
