### PR TITLE
added denominator_value to oracle drug-strength load file.

### DIFF
--- a/Oracle/VocabImport/drug_strength.ctl
+++ b/Oracle/VocabImport/drug_strength.ctl
@@ -12,6 +12,7 @@ trailing nullcols
   amount_unit_concept_id,
   numerator_value,
   numerator_unit_concept_id,
+  denominator_value,
   denominator_unit_concept_id,
   valid_start_date DATE 'YYYYMMDD',
   valid_end_date DATE 'YYYYMMDD',


### PR DESCRIPTION
This column was added to the table, but not updated in the load scripts. The postgres and sql server do not list individual columns, so no changes are needed for them.