### PR TITLE
Obs period datetime patch

### DIFF
--- a/Oracle/OMOP CDM ddl - Oracle.sql
+++ b/Oracle/OMOP CDM ddl - Oracle.sql
@@ -254,10 +254,8 @@ CREATE TABLE observation_period
      observation_period_id				INTEGER		NOT NULL , 
      person_id							INTEGER		NOT NULL , 
      observation_period_start_date		DATE		NOT NULL , 
-     observation_period_start_datetime		TIMESTAMP WITH TIME ZONE		NOT NULL ,
      observation_period_end_date		DATE		NOT NULL ,
-     observation_period_end_datetime		TIMESTAMP WITH TIME ZONE		NOT NULL ,
-	 period_type_concept_id				INTEGER		NOT NULL
+     period_type_concept_id				INTEGER		NOT NULL
     ) 
 ;
 

--- a/PostgreSQL/OMOP CDM ddl - PostgreSQL.sql
+++ b/PostgreSQL/OMOP CDM ddl - PostgreSQL.sql
@@ -254,10 +254,8 @@ CREATE TABLE observation_period
      observation_period_id				INTEGER		NOT NULL , 
      person_id							INTEGER		NOT NULL , 
      observation_period_start_date		DATE		NOT NULL , 
-     observation_period_start_datetime		TIMESTAMP		NOT NULL ,
      observation_period_end_date		DATE		NOT NULL ,
-     observation_period_end_datetime		TIMESTAMP		NOT NULL ,
-	 period_type_concept_id				INTEGER		NOT NULL
+     period_type_concept_id				INTEGER		NOT NULL
     ) 
 ;
 

--- a/Sql Server/OMOP CDM ddl - SQL Server.sql
+++ b/Sql Server/OMOP CDM ddl - SQL Server.sql
@@ -254,9 +254,7 @@ CREATE TABLE observation_period
   observation_period_id				INTEGER		NOT NULL ,
   person_id							INTEGER		NOT NULL ,
   observation_period_start_date		DATE		NOT NULL ,
-  observation_period_start_datetime		DATETIME2		NOT NULL ,
   observation_period_end_date		DATE		NOT NULL ,
-  observation_period_end_datetime		DATETIME2		NOT NULL ,
   period_type_concept_id				INTEGER		NOT NULL
 )
 ;


### PR DESCRIPTION
This removes datetime fields from OBSERVATION_PERIOD table DDL in sql server, postgres and oracle. Impala did not have this issue.