### PR TITLE
fixing a typo in code that crashes DDL

### DIFF
--- a/PostgreSQL/OMOP CDM ddl - PostgreSQL.sql
+++ b/PostgreSQL/OMOP CDM ddl - PostgreSQL.sql
@@ -315,7 +315,7 @@ CREATE TABLE visit_occurrence
 	 visit_source_concept_id		INTEGER			NULL ,
 	 admitting_source_concept_id	INTEGER			NULL ,
 	 admitting_source_value			VARCHAR(50)		NULL ,
-	 discharge_to_concept_id		INTEGER(50)		NULL ,
+	 discharge_to_concept_id		INTEGER		NULL ,
 	 discharge_to_source_value		VARCHAR(50)		NULL ,
 	 preceding_visit_occurrence_id	INTEGER			NULL
     ) 


### PR DESCRIPTION
typo that siad integer(50) - changed to just integer