### PR TITLE
Add a unique constraint to concept_synonym to prevent duplicates.

### DIFF
--- a/Oracle/OMOP CDM constraints - Oracle.sql
+++ b/Oracle/OMOP CDM constraints - Oracle.sql
@@ -80,6 +80,7 @@ ALTER TABLE cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (
 
 ALTER TABLE attribute_definition ADD CONSTRAINT xpk_attribute_definition PRIMARY KEY (attribute_definition_id);
 
+ALTER TABLE concept_synonym ADD CONSTRAINT uq_concept_synonym UNIQUE (concept_id, concept_synonym_name, language_concept_id);
 
 /**************************
 

--- a/PostgreSQL/OMOP CDM constraints - PostgreSQL.sql
+++ b/PostgreSQL/OMOP CDM constraints - PostgreSQL.sql
@@ -80,6 +80,7 @@ ALTER TABLE cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (
 
 ALTER TABLE attribute_definition ADD CONSTRAINT xpk_attribute_definition PRIMARY KEY (attribute_definition_id);
 
+ALTER TABLE concept_synonym ADD CONSTRAINT uq_concept_synonym UNIQUE (concept_id, concept_synonym_name, language_concept_id);
 
 /**************************
 

--- a/Sql Server/OMOP CDM constraints - SQL Server.sql
+++ b/Sql Server/OMOP CDM constraints - SQL Server.sql
@@ -80,6 +80,7 @@ ALTER TABLE cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY N
 
 ALTER TABLE attribute_definition ADD CONSTRAINT xpk_attribute_definition PRIMARY KEY NONCLUSTERED (attribute_definition_id);
 
+ALTER TABLE concept_synonym ADD CONSTRAINT uq_concept_synonym UNIQUE (concept_id, concept_synonym_name, language_concept_id);
 
 /**************************
 


### PR DESCRIPTION
Ensure duplicate rows are not inserted into the **concept_synonym** table.  

In the future this table may have a primary key. In the mean time, we should add a unique constraint to block duplicates from being inserted. 

Based on a conversation here:
http://forums.ohdsi.org/t/duplicate-entries-in-concept-synonym/1448