### PR TITLE
typo in column name

### DIFF
--- a/Sql Server/OMOP CDM ddl - SQL Server.sql
+++ b/Sql Server/OMOP CDM ddl - SQL Server.sql
@@ -613,7 +613,7 @@ CREATE TABLE cost
   payer_plan_period_id			INTEGER			NULL ,
   amount_allowed		FLOAT			NULL ,
   revenue_code_concept_id		INTEGER			NULL ,
-  reveue_code_source_value    VARCHAR(50)    NULL,
+  revenue_code_source_value    VARCHAR(50)    NULL,
   drg_concept_id			INTEGER		NULL,
   drg_source_value			CHAR(3)		NULL
 )


### PR DESCRIPTION
using the SqlRender mechanism, this fix will propagate to other flavors.
see #118 


reveue_code_source_value was mispelled
fixes #109  in "future v5.3" (master)