### PR TITLE
Closes #149, vocabulary_version no longer required

### DIFF
--- a/BigQuery/OMOP CDM bigquery ddl.txt
+++ b/BigQuery/OMOP CDM bigquery ddl.txt
@@ -17,7 +17,7 @@ create table vocabulary (
   vocabulary_id			    varchar(20)		not null,
   vocabulary_name		    varchar(255)	not null,
   vocabulary_reference	varchar(255)	not null,
-  vocabulary_version	  varchar(255)	not null,
+  vocabulary_version	  varchar(255)	null,
   vocabulary_concept_id	integer			  not null
 )
 ;
@@ -390,8 +390,8 @@ create table measurement
   person_id						          integer			not null ,
   measurement_concept_id		    integer			not null ,
   measurement_date				      date			  not null ,
+  measurement_datetime          datetime    null ,
   measurement_time              varchar(10) null ,
-  measurement_datetime			    datetime		null ,
   measurement_type_concept_id	  integer			not null ,
   operator_concept_id			      integer			null ,
   value_as_number				        float			  null ,
@@ -551,7 +551,7 @@ create table payer_plan_period
   sponsor_source_concept_id     integer       null ,
   family_source_value			      varchar(50)	  null ,
   stop_reason_concept_id        integer       null ,
-  stop_reason_source_value      integer       null ,
+  stop_reason_source_value      varchar(50)   null ,
   stop_reason_source_concept_id integer       null
 )
 ;

--- a/Documentation/CommonDataModel_Wiki_Files/StandardizedVocabularies/VOCABULARY.md
+++ b/Documentation/CommonDataModel_Wiki_Files/StandardizedVocabularies/VOCABULARY.md
@@ -5,7 +5,7 @@ Field|Required|Type|Description
 |vocabulary_id|Yes|varchar(20)|A unique identifier for each Vocabulary, such as ICD9CM, SNOMED, Visit.|
 |vocabulary_name|Yes|varchar(255)|The name describing the vocabulary, for example "International Classification of Diseases, Ninth Revision, Clinical Modification, Volume 1 and 2 (NCHS)" etc.|
 |vocabulary_reference|Yes|varchar(255)|External reference to documentation or available download of the about the vocabulary.|
-|vocabulary_version|Yes|varchar(255)|Version of the Vocabulary as indicated in the source.|
+|vocabulary_version|No|varchar(255)|Version of the Vocabulary as indicated in the source.|
 |vocabulary_concept_id|Yes|integer|A foreign key that refers to a standard concept identifier in the CONCEPT table for the Vocabulary the VOCABULARY record belongs to.|
 
 ### Conventions

--- a/Impala/OMOP CDM impala ddl.txt
+++ b/Impala/OMOP CDM impala ddl.txt
@@ -818,6 +818,8 @@ CREATE TABLE measurement
 
     measurement_datetime TIMESTAMP,
 
+    measurement_time VARCHAR(10),
+
     measurement_type_concept_id INTEGER,
 
     operator_concept_id INTEGER,
@@ -1134,7 +1136,7 @@ CREATE TABLE payer_plan_period
 
     stop_reason_concept_id INTEGER,
 
-    stop_reason_source_value INTEGER,
+    stop_reason_source_value VARCHAR(50),
 
     stop_reason_source_concept_id INTEGER
 )

--- a/Netezza/OMOP CDM netezza ddl.txt
+++ b/Netezza/OMOP CDM netezza ddl.txt
@@ -28,7 +28,7 @@
 
 netezza script to create OMOP common data model version 5.3
 
-last revised: 6-Nov-2017
+last revised: 8-Jan-2018
 
 Authors:  Patrick Ryan, Christian Reich, Clair Blacketer
 
@@ -64,7 +64,7 @@ CREATE TABLE vocabulary (
   vocabulary_id			    VARCHAR(20)		NOT NULL,
   vocabulary_name		    VARCHAR(255)	NOT NULL,
   vocabulary_reference	VARCHAR(255)	NOT NULL,
-  vocabulary_version	  VARCHAR(255)	NOT NULL,
+  vocabulary_version	  VARCHAR(255)	NULL,
   vocabulary_concept_id	INTEGER			  NOT NULL
 )
 DISTRIBUTE ON RANDOM
@@ -479,7 +479,8 @@ CREATE TABLE measurement
   person_id						          INTEGER			NOT NULL ,
   measurement_concept_id		    INTEGER			NOT NULL ,
   measurement_date				      DATE			  NOT NULL ,
-  measurement_datetime			    DATETIME		NULL ,
+  measurement_datetime			    DATETIME	  NULL ,
+  measurement_time              VARCHAR(10) NULL ,
   measurement_type_concept_id	  INTEGER			NOT NULL ,
   operator_concept_id			      INTEGER			NULL ,
   value_as_number				        REAL			  NULL ,
@@ -665,7 +666,7 @@ CREATE TABLE payer_plan_period
   sponsor_source_concept_id     INTEGER       NULL ,
   family_source_value			      VARCHAR(50)	  NULL ,
   stop_reason_concept_id        INTEGER       NULL ,
-  stop_reason_source_value      INTEGER       NULL ,
+  stop_reason_source_value      VARCHAR(50)   NULL ,
   stop_reason_source_concept_id INTEGER       NULL
 )
 DISTRIBUTE ON (person_id)

--- a/Oracle/OMOP CDM oracle ddl.txt
+++ b/Oracle/OMOP CDM oracle ddl.txt
@@ -62,7 +62,7 @@ CREATE TABLE vocabulary (
   vocabulary_id			    VARCHAR(20)		NOT NULL,
   vocabulary_name		    VARCHAR(255)	NOT NULL,
   vocabulary_reference	VARCHAR(255)	NOT NULL,
-  vocabulary_version	  VARCHAR(255)	NOT NULL,
+  vocabulary_version	  VARCHAR(255)	NULL,
   vocabulary_concept_id	INTEGER			  NOT NULL
 )
 ;
@@ -447,8 +447,8 @@ CREATE TABLE measurement
   person_id						          INTEGER			NOT NULL ,
   measurement_concept_id		    INTEGER			NOT NULL ,
   measurement_date				      DATE			  NOT NULL ,
+  measurement_datetime			    TIMESTAMP  	NULL ,
   measurement_time              VARCHAR(10) NULL ,
-  measurement_datetime			    TIMESTAMP		NULL ,
   measurement_type_concept_id	  INTEGER			NOT NULL ,
   operator_concept_id			      INTEGER			NULL ,
   value_as_number				        FLOAT			  NULL ,
@@ -623,7 +623,7 @@ CREATE TABLE payer_plan_period
   sponsor_source_concept_id     INTEGER       NULL ,
   family_source_value			      VARCHAR(50)	  NULL ,
   stop_reason_concept_id        INTEGER       NULL ,
-  stop_reason_source_value      INTEGER       NULL ,
+  stop_reason_source_value      VARCHAR(50)      NULL ,
   stop_reason_source_concept_id INTEGER       NULL
 )
 ;

--- a/ParallelDataWarehouse/OMOP CDM pdw ddl.txt
+++ b/ParallelDataWarehouse/OMOP CDM pdw ddl.txt
@@ -60,7 +60,7 @@ WITH (DISTRIBUTION = REPLICATE);
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  vocabulary  (vocabulary_id			    VARCHAR(20)		NOT NULL,
   vocabulary_name		    VARCHAR(255)	NOT NULL,
   vocabulary_reference	VARCHAR(255)	NOT NULL,
-  vocabulary_version	  VARCHAR(255)	NOT NULL,
+  vocabulary_version	  VARCHAR(255)	NULL,
   vocabulary_concept_id	INTEGER			  NOT NULL
 )
 WITH (DISTRIBUTION = REPLICATE);
@@ -207,7 +207,7 @@ Standardized clinical data
 
 ************************/
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  person
  (person_id						        INTEGER	  	NOT NULL ,
   gender_concept_id				    INTEGER	  	NOT NULL ,
@@ -231,7 +231,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  person
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  observation_period
  (observation_period_id				      INTEGER		NOT NULL ,
   person_id							            INTEGER		NOT NULL ,
@@ -242,7 +242,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  observation_period
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  specimen
  (specimen_id						      INTEGER			NOT NULL ,
   person_id							      INTEGER			NOT NULL ,
@@ -263,7 +263,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  specimen
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  death
  (person_id							  INTEGER			NOT NULL ,
   death_date							DATE			  NOT NULL ,
@@ -276,7 +276,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  death
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  visit_occurrence
  (visit_occurrence_id			      INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
@@ -299,7 +299,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  visit_occurrence
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  visit_detail
  (visit_detail_id             INTEGER     NOT NULL ,
   person_id                   INTEGER     NOT NULL ,
@@ -324,7 +324,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  visit_detail
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  procedure_occurrence
  (procedure_occurrence_id		  INTEGER			NOT NULL ,
   person_id						        INTEGER			NOT NULL ,
@@ -344,7 +344,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  procedure_occurrence
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  drug_exposure
  (drug_exposure_id				      INTEGER			  NOT NULL ,
   person_id						          INTEGER			  NOT NULL ,
@@ -373,7 +373,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  drug_exposure
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  device_exposure
  (device_exposure_id			        INTEGER		  	NOT NULL ,
   person_id						            INTEGER			  NOT NULL ,
@@ -394,7 +394,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  device_exposure
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  condition_occurrence
  (condition_occurrence_id		    INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
@@ -416,14 +416,14 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  condition_occurrence
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  measurement
  (measurement_id				        INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
   measurement_concept_id		    INTEGER			NOT NULL ,
   measurement_date				      DATE			  NOT NULL ,
+  measurement_datetime			    DATETIME  	NULL ,
   measurement_time              VARCHAR(10) NULL ,
-  measurement_datetime			    DATETIME		NULL ,
   measurement_type_concept_id	  INTEGER			NOT NULL ,
   operator_concept_id			      INTEGER			NULL ,
   value_as_number				        FLOAT			  NULL ,
@@ -442,7 +442,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  measurement
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  note
  (note_id						    INTEGER			  NOT NULL ,
   person_id						  INTEGER			  NOT NULL ,
@@ -482,7 +482,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  note_nlp
 WITH (DISTRIBUTION = REPLICATE);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  observation
  (observation_id					      INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
@@ -573,7 +573,7 @@ Standardized health economics
 ************************/
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  payer_plan_period
  (payer_plan_period_id			    INTEGER			  NOT NULL ,
   person_id						          INTEGER			  NOT NULL ,
@@ -590,7 +590,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  payer_plan_period
   sponsor_source_concept_id     INTEGER       NULL ,
   family_source_value			      VARCHAR(50)	  NULL ,
   stop_reason_concept_id        INTEGER       NULL ,
-  stop_reason_source_value      INTEGER       NULL ,
+  stop_reason_source_value      VARCHAR(50)      NULL ,
   stop_reason_source_concept_id INTEGER       NULL
 )
 WITH (DISTRIBUTION = HASH(person_id));
@@ -630,7 +630,7 @@ Standardized derived elements
 ************************/
 
 
---HINT DISTRIBUTE_ON_KEY(subject_id)
+--HINT DISTRIBUTE_ON_KEY(subject_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  cohort
  (cohort_definition_id	INTEGER		NOT NULL ,
   subject_id						INTEGER		NOT NULL ,
@@ -640,7 +640,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  cohort
 WITH (DISTRIBUTION = HASH(subject_id));
 
 
---HINT DISTRIBUTE_ON_KEY(subject_id)
+--HINT DISTRIBUTE_ON_KEY(subject_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  cohort_attribute
  (cohort_definition_id		INTEGER		NOT NULL ,
   subject_id						  INTEGER		NOT NULL ,
@@ -653,7 +653,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  cohort_attribute
 WITH (DISTRIBUTION = HASH(subject_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  drug_era
  (drug_era_id					INTEGER			NOT NULL ,
   person_id						INTEGER			NOT NULL ,
@@ -666,7 +666,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  drug_era
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  dose_era
  (dose_era_id					  INTEGER			NOT NULL ,
   person_id						  INTEGER			NOT NULL ,
@@ -679,7 +679,7 @@ IF XACT_STATE() = 1 COMMIT; CREATE TABLE  dose_era
 WITH (DISTRIBUTION = HASH(person_id));
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 IF XACT_STATE() = 1 COMMIT; CREATE TABLE  condition_era
  (condition_era_id				    INTEGER			NOT NULL ,
   person_id						        INTEGER			NOT NULL ,

--- a/PostgreSQL/OMOP CDM postgresql ddl.txt
+++ b/PostgreSQL/OMOP CDM postgresql ddl.txt
@@ -62,7 +62,7 @@ CREATE TABLE vocabulary (
   vocabulary_id			    VARCHAR(20)		NOT NULL,
   vocabulary_name		    VARCHAR(255)	NOT NULL,
   vocabulary_reference	VARCHAR(255)	NOT NULL,
-  vocabulary_version	  VARCHAR(255)	NOT NULL,
+  vocabulary_version	  VARCHAR(255)	NULL,
   vocabulary_concept_id	INTEGER			  NOT NULL
 )
 ;
@@ -447,8 +447,8 @@ CREATE TABLE measurement
   person_id						          INTEGER			NOT NULL ,
   measurement_concept_id		    INTEGER			NOT NULL ,
   measurement_date				      DATE			  NOT NULL ,
+  measurement_datetime			    TIMESTAMP  	NULL ,
   measurement_time              VARCHAR(10) NULL ,
-  measurement_datetime			    TIMESTAMP		NULL ,
   measurement_type_concept_id	  INTEGER			NOT NULL ,
   operator_concept_id			      INTEGER			NULL ,
   value_as_number				        NUMERIC			  NULL ,
@@ -623,7 +623,7 @@ CREATE TABLE payer_plan_period
   sponsor_source_concept_id     INTEGER       NULL ,
   family_source_value			      VARCHAR(50)	  NULL ,
   stop_reason_concept_id        INTEGER       NULL ,
-  stop_reason_source_value      INTEGER       NULL ,
+  stop_reason_source_value      VARCHAR(50)      NULL ,
   stop_reason_source_concept_id INTEGER       NULL
 )
 ;

--- a/Redshift/OMOP CDM redshift ddl.txt
+++ b/Redshift/OMOP CDM redshift ddl.txt
@@ -60,7 +60,7 @@ DISTSTYLE ALL;
 CREATE TABLE vocabulary  (vocabulary_id			    VARCHAR(20)		NOT NULL,
   vocabulary_name		    VARCHAR(255)	NOT NULL,
   vocabulary_reference	VARCHAR(255)	NOT NULL,
-  vocabulary_version	  VARCHAR(255)	NOT NULL,
+  vocabulary_version	  VARCHAR(255)	NULL,
   vocabulary_concept_id	INTEGER			  NOT NULL
 )
 DISTSTYLE ALL;
@@ -207,7 +207,7 @@ Standardized clinical data
 
 ************************/
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE person
  (person_id						        INTEGER	  	NOT NULL ,
   gender_concept_id				    INTEGER	  	NOT NULL ,
@@ -231,7 +231,7 @@ CREATE TABLE person
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE observation_period
  (observation_period_id				      INTEGER		NOT NULL ,
   person_id							            INTEGER		NOT NULL ,
@@ -242,7 +242,7 @@ CREATE TABLE observation_period
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE specimen
  (specimen_id						      INTEGER			NOT NULL ,
   person_id							      INTEGER			NOT NULL ,
@@ -263,7 +263,7 @@ CREATE TABLE specimen
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE death
  (person_id							  INTEGER			NOT NULL ,
   death_date							DATE			  NOT NULL ,
@@ -276,7 +276,7 @@ CREATE TABLE death
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE visit_occurrence
  (visit_occurrence_id			      INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
@@ -299,7 +299,7 @@ CREATE TABLE visit_occurrence
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE visit_detail
  (visit_detail_id             INTEGER     NOT NULL ,
   person_id                   INTEGER     NOT NULL ,
@@ -324,7 +324,7 @@ CREATE TABLE visit_detail
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE procedure_occurrence
  (procedure_occurrence_id		  INTEGER			NOT NULL ,
   person_id						        INTEGER			NOT NULL ,
@@ -344,7 +344,7 @@ CREATE TABLE procedure_occurrence
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE drug_exposure
  (drug_exposure_id				      INTEGER			  NOT NULL ,
   person_id						          INTEGER			  NOT NULL ,
@@ -373,7 +373,7 @@ CREATE TABLE drug_exposure
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE device_exposure
  (device_exposure_id			        INTEGER		  	NOT NULL ,
   person_id						            INTEGER			  NOT NULL ,
@@ -394,7 +394,7 @@ CREATE TABLE device_exposure
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE condition_occurrence
  (condition_occurrence_id		    INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
@@ -416,14 +416,14 @@ CREATE TABLE condition_occurrence
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE measurement
  (measurement_id				        INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
   measurement_concept_id		    INTEGER			NOT NULL ,
   measurement_date				      DATE			  NOT NULL ,
+  measurement_datetime			    TIMESTAMP  	NULL ,
   measurement_time              VARCHAR(10) NULL ,
-  measurement_datetime			    TIMESTAMP		NULL ,
   measurement_type_concept_id	  INTEGER			NOT NULL ,
   operator_concept_id			      INTEGER			NULL ,
   value_as_number				        FLOAT			  NULL ,
@@ -442,7 +442,7 @@ CREATE TABLE measurement
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE note
  (note_id						    INTEGER			  NOT NULL ,
   person_id						  INTEGER			  NOT NULL ,
@@ -482,7 +482,7 @@ CREATE TABLE note_nlp
 DISTSTYLE ALL;
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE observation
  (observation_id					      INTEGER			NOT NULL ,
   person_id						          INTEGER			NOT NULL ,
@@ -573,7 +573,7 @@ Standardized health economics
 ************************/
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE payer_plan_period
  (payer_plan_period_id			    INTEGER			  NOT NULL ,
   person_id						          INTEGER			  NOT NULL ,
@@ -590,7 +590,7 @@ CREATE TABLE payer_plan_period
   sponsor_source_concept_id     INTEGER       NULL ,
   family_source_value			      VARCHAR(50)	  NULL ,
   stop_reason_concept_id        INTEGER       NULL ,
-  stop_reason_source_value      INTEGER       NULL ,
+  stop_reason_source_value      VARCHAR(50)      NULL ,
   stop_reason_source_concept_id INTEGER       NULL
 )
 DISTKEY(person_id);
@@ -630,7 +630,7 @@ Standardized derived elements
 ************************/
 
 
---HINT DISTRIBUTE_ON_KEY(subject_id)
+--HINT DISTRIBUTE_ON_KEY(subject_id) 
 CREATE TABLE cohort
  (cohort_definition_id	INTEGER		NOT NULL ,
   subject_id						INTEGER		NOT NULL ,
@@ -640,7 +640,7 @@ CREATE TABLE cohort
 DISTKEY(subject_id);
 
 
---HINT DISTRIBUTE_ON_KEY(subject_id)
+--HINT DISTRIBUTE_ON_KEY(subject_id) 
 CREATE TABLE cohort_attribute
  (cohort_definition_id		INTEGER		NOT NULL ,
   subject_id						  INTEGER		NOT NULL ,
@@ -653,7 +653,7 @@ CREATE TABLE cohort_attribute
 DISTKEY(subject_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE drug_era
  (drug_era_id					INTEGER			NOT NULL ,
   person_id						INTEGER			NOT NULL ,
@@ -666,7 +666,7 @@ CREATE TABLE drug_era
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE dose_era
  (dose_era_id					  INTEGER			NOT NULL ,
   person_id						  INTEGER			NOT NULL ,
@@ -679,7 +679,7 @@ CREATE TABLE dose_era
 DISTKEY(person_id);
 
 
---HINT DISTRIBUTE_ON_KEY(person_id)
+--HINT DISTRIBUTE_ON_KEY(person_id) 
 CREATE TABLE condition_era
  (condition_era_id				    INTEGER			NOT NULL ,
   person_id						        INTEGER			NOT NULL ,

--- a/Sql Server/OMOP CDM sql server ddl.txt
+++ b/Sql Server/OMOP CDM sql server ddl.txt
@@ -62,7 +62,7 @@ CREATE TABLE vocabulary (
   vocabulary_id			    VARCHAR(20)		NOT NULL,
   vocabulary_name		    VARCHAR(255)	NOT NULL,
   vocabulary_reference	VARCHAR(255)	NOT NULL,
-  vocabulary_version	  VARCHAR(255)	NOT NULL,
+  vocabulary_version	  VARCHAR(255)	NULL,
   vocabulary_concept_id	INTEGER			  NOT NULL
 )
 ;
@@ -447,8 +447,8 @@ CREATE TABLE measurement
   person_id						          INTEGER			NOT NULL ,
   measurement_concept_id		    INTEGER			NOT NULL ,
   measurement_date				      DATE			  NOT NULL ,
+  measurement_datetime			    DATETIME  	NULL ,
   measurement_time              VARCHAR(10) NULL ,
-  measurement_datetime			    DATETIME		NULL ,
   measurement_type_concept_id	  INTEGER			NOT NULL ,
   operator_concept_id			      INTEGER			NULL ,
   value_as_number				        FLOAT			  NULL ,
@@ -623,7 +623,7 @@ CREATE TABLE payer_plan_period
   sponsor_source_concept_id     INTEGER       NULL ,
   family_source_value			      VARCHAR(50)	  NULL ,
   stop_reason_concept_id        INTEGER       NULL ,
-  stop_reason_source_value      INTEGER       NULL ,
+  stop_reason_source_value      VARCHAR(50)      NULL ,
   stop_reason_source_concept_id INTEGER       NULL
 )
 ;


### PR DESCRIPTION
Fixes vocabulary_version, which was changed to required. It is now back to 'not required' as not every vocabulary has version information