### PR TITLE
BigQuery Compatible Table Creations

### DIFF
--- a/BigQuery/OMOP CDM bigquery ddl.txt
+++ b/BigQuery/OMOP CDM bigquery ddl.txt
@@ -1,93 +1,93 @@
 create table concept (
-  concept_id			    integer			  not null ,
-  concept_name			  varchar(255)	not null ,
-  domain_id				    varchar(20)		not null ,
-  vocabulary_id			  varchar(20)		not null ,
-  concept_class_id		varchar(20)		not null ,
-  standard_concept		varchar(1)		null ,
-  concept_code			  varchar(50)		not null ,
-  valid_start_date		date			    not null ,
-  valid_end_date		  date			    not null ,
-  invalid_reason		  varchar(1)		null
+  concept_id			    INT64			  not null ,
+  concept_name			  STRING     	not null ,
+  domain_id				    STRING   		not null ,
+  vocabulary_id			  STRING   		not null ,
+  concept_class_id		STRING  		not null ,
+  standard_concept		STRING  		null ,
+  concept_code			  STRING  		not null ,
+  valid_start_DATE		DATE			  not null ,
+  valid_end_DATE		  DATE			  not null ,
+  invalid_reason		  STRING  		null
 )
 ;
 
 
 create table vocabulary (
-  vocabulary_id			    varchar(20)		not null,
-  vocabulary_name		    varchar(255)	not null,
-  vocabulary_reference	varchar(255)	not null,
-  vocabulary_version	  varchar(255)	null,
-  vocabulary_concept_id	integer			  not null
+  vocabulary_id			    STRING   		not null,
+  vocabulary_name		    STRING     	not null,
+  vocabulary_reference	STRING     	not null,
+  vocabulary_version	  STRING     	null,
+  vocabulary_concept_id	INT64			  not null
 )
 ;
 
 
 create table domain (
-  domain_id			    varchar(20)		not null,
-  domain_name		    varchar(255)	not null,
-  domain_concept_id	integer			  not null
+  domain_id			    STRING   		not null,
+  domain_name		    STRING    	not null,
+  domain_concept_id	INT64			  not null
 )
 ;
 
 
 create table concept_class (
-  concept_class_id			    varchar(20)		not null,
-  concept_class_name		    varchar(255)	not null,
-  concept_class_concept_id	integer			  not null
+  concept_class_id			    STRING  		not null,
+  concept_class_name		    STRING    	not null,
+  concept_class_concept_id	INT64		 	  not null
 )
 ;
 
 
 create table concept_relationship (
-  concept_id_1			integer			not null,
-  concept_id_2			integer			not null,
-  relationship_id		varchar(20)	not null,
-  valid_start_date	date			  not null,
-  valid_end_date		date			  not null,
-  invalid_reason		varchar(1)	null
+  concept_id_1			INT64			not null,
+  concept_id_2			INT64			not null,
+  relationship_id		STRING  	not null,
+  valid_start_DATE	DATE			not null,
+  valid_end_DATE		DATE			not null,
+  invalid_reason		STRING  	null
   )
 ;
 
 
 create table relationship (
-  relationship_id			    varchar(20)		not null,
-  relationship_name			  varchar(255)	not null,
-  is_hierarchical			    varchar(1)		not null,
-  defines_ancestry			  varchar(1)		not null,
-  reverse_relationship_id	varchar(20)		not null,
-  relationship_concept_id	integer			  not null
+  relationship_id			    STRING   		not null,
+  relationship_name			  STRING    	not null,
+  is_hierarchical			    STRING  		not null,
+  defines_ancestry			  STRING  		not null,
+  reverse_relationship_id	STRING  		not null,
+  relationship_concept_id	INT64			  not null
 )
 ;
 
 
 create table concept_synonym (
-  concept_id			      integer			  not null,
-  concept_synonym_name	varchar(1000)	not null,
-  language_concept_id	  integer			  not null
+  concept_id			      INT64			  not null,
+  concept_synonym_name	STRING    	not null,
+  language_concept_id	  INT64			  not null
 )
 ;
 
 
 create table concept_ancestor (
-  ancestor_concept_id		    integer		not null,
-  descendant_concept_id		  integer		not null,
-  min_levels_of_separation	integer		not null,
-  max_levels_of_separation	integer		not null
+  ancestor_concept_id		    INT64		not null,
+  descendant_concept_id		  INT64		not null,
+  min_levels_of_separation	INT64		not null,
+  max_levels_of_separation	INT64		not null
 )
 ;
 
 
 create table source_to_concept_map (
-  source_code				      varchar(50)		not null,
-  source_concept_id			  integer			  not null,
-  source_vocabulary_id		varchar(20)		not null,
-  source_code_description	varchar(255)	null,
-  target_concept_id			  integer			  not null,
-  target_vocabulary_id		varchar(20)		not null,
-  valid_start_date			  date			    not null,
-  valid_end_date			    date			    not null,
-  invalid_reason			    varchar(1)		null
+  source_code				      STRING  		not null,
+  source_concept_id			  INT64			  not null,
+  source_vocabulary_id		STRING  		not null,
+  source_code_description	STRING    	null,
+  target_concept_id			  INT64			  not null,
+  target_vocabulary_id		STRING  		not null,
+  valid_start_DATE			  DATE		    not null,
+  valid_end_DATE			    DATE		    not null,
+  invalid_reason			    STRING  		null
 )
 ;
 
@@ -95,70 +95,70 @@ create table source_to_concept_map (
 
 
 create table drug_strength (
-  drug_concept_id				      integer		  not null,
-  ingredient_concept_id			  integer		  not null,
-  amount_value					      float		    null,
-  amount_unit_concept_id		  integer		  null,
-  numerator_value				      float		    null,
-  numerator_unit_concept_id		integer		  null,
-  denominator_value				    float		    null,
-  denominator_unit_concept_id	integer		  null,
-  box_size						        integer		  null,
-  valid_start_date				    date		    not null,
-  valid_end_date				      date		    not null,
-  invalid_reason				      varchar(1)  null
+  drug_concept_id				      INT64		  not null,
+  ingredient_concept_id			  INT64		  not null,
+  amount_value					      FLOAT64		    null,
+  amount_unit_concept_id		  INT64		  null,
+  numerator_value				      FLOAT64		    null,
+  numerator_unit_concept_id		INT64		  null,
+  denominator_value				    FLOAT64		    null,
+  denominator_unit_concept_id	INT64		  null,
+  box_size						        INT64		  null,
+  valid_start_DATE				    DATE		    not null,
+  valid_end_DATE				      DATE		    not null,
+  invalid_reason				      STRING     null
 )
 ;
 
 
 
 create table cohort_definition (
-  cohort_definition_id				    integer			  not null,
-  cohort_definition_name			    varchar(255)	not null,
-  cohort_definition_description		varchar(max)	null,
-  definition_type_concept_id		  integer			  not null,
-  cohort_definition_syntax			  varchar(max)	null,
-  subject_concept_id				      integer			  not null,
-  cohort_initiation_date			    date			    null
+  cohort_definition_id				    INT64			  not null,
+  cohort_definition_name			    STRING    	not null,
+  cohort_definition_description		STRING    	null,
+  definition_type_concept_id		  INT64			  not null,
+  cohort_definition_syntax			  STRING     	null,
+  subject_concept_id				      INT64			  not null,
+  cohort_initiation_DATE			    DATE			    null
 )
 ;
 
 
 create table attribute_definition (
-  attribute_definition_id		  integer			  not null,
-  attribute_name				      varchar(255)	not null,
-  attribute_description			  varchar(max)	null,
-  attribute_type_concept_id		integer			  not null,
-  attribute_syntax				    varchar(max)	null
+  attribute_definition_id		  INT64			  not null,
+  attribute_name				      STRING    	not null,
+  attribute_description			  STRING    	null,
+  attribute_type_concept_id		INT64			  not null,
+  attribute_syntax				    STRING    	null
 )
 ;
 
 
 create table cdm_source
 (
-  cdm_source_name					        varchar(255)	not null ,
-  cdm_source_abbreviation			    varchar(25)		null ,
-  cdm_holder							        varchar(255)	null ,
-  source_description					    varchar(max)	null ,
-  source_documentation_reference	varchar(255)	null ,
-  cdm_etl_reference					      varchar(255)	null ,
-  source_release_date				      date			    null ,
-  cdm_release_date					      date			    null ,
-  cdm_version						          varchar(10)		null ,
-  vocabulary_version					    varchar(20)		null
+  cdm_source_name					        STRING      	not null ,
+  cdm_source_abbreviation			    STRING    		null ,
+  cdm_holder							        STRING      	null ,
+  source_description					    STRING      	null ,
+  source_documentation_reference	STRING      	null ,
+  cdm_etl_reference					      STRING      	null ,
+  source_release_DATE				      DATE			    null ,
+  cdm_release_DATE					      DATE			    null ,
+  cdm_version						          STRING    		null ,
+  vocabulary_version					    STRING    		null
 )
 ;
 
 
 create table metadata
 (
-  metadata_concept_id       integer       not null ,
-  metadata_type_concept_id  integer       not null ,
-  name                      varchar(250)  not null ,
-  value_as_string           varchar(max)  null ,
-  value_as_concept_id       integer       null ,
-  metadata_date             date          null ,
-  metadata_datetime         datetime      null
+  metadata_concept_id       INT64       not null ,
+  metadata_type_concept_id  INT64       not null ,
+  name                      STRING      not null ,
+  value_as_string           STRING      null ,
+  value_as_concept_id       INT64       null ,
+  metadata_DATE             DATE          null ,
+  metadata_DATETIME         DATETIME      null
 )
 ;
 
@@ -167,24 +167,24 @@ create table metadata
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table person
 (
-  person_id						        integer	  	not null ,
-  gender_concept_id				    integer	  	not null ,
-  year_of_birth					      integer	  	not null ,
-  month_of_birth				      integer	  	null,
-  day_of_birth					      integer	  	null,
-  birth_datetime				      datetime	  null,
-  race_concept_id				      integer		  not null,
-  ethnicity_concept_id			  integer	  	not null,
-  location_id					        integer		  null,
-  provider_id					        integer		  null,
-  care_site_id					      integer		  null,
-  person_source_value			    varchar(50) null,
-  gender_source_value			    varchar(50) null,
-  gender_source_concept_id	  integer		  null,
-  race_source_value				    varchar(50) null,
-  race_source_concept_id		  integer		  null,
-  ethnicity_source_value		  varchar(50) null,
-  ethnicity_source_concept_id	integer		  null
+  person_id						        INT64	  	not null ,
+  gender_concept_id				    INT64	  	not null ,
+  year_of_birth					      INT64	  	not null ,
+  month_of_birth				      INT64	  	null,
+  day_of_birth					      INT64	  	null,
+  birth_DATETIME				      DATETIME	  null,
+  race_concept_id				      INT64		  not null,
+  ethnicity_concept_id			  INT64	  	not null,
+  location_id					        INT64		  null,
+  provider_id					        INT64		  null,
+  care_site_id					      INT64		  null,
+  person_source_value			    STRING    null,
+  gender_source_value			    STRING    null,
+  gender_source_concept_id	  INT64		  null,
+  race_source_value				    STRING    null,
+  race_source_concept_id		  INT64		  null,
+  ethnicity_source_value		  STRING    null,
+  ethnicity_source_concept_id	INT64		  null
 )
 ;
 
@@ -192,11 +192,11 @@ create table person
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table observation_period
 (
-  observation_period_id				      integer		not null ,
-  person_id							            integer		not null ,
-  observation_period_start_date		  date		  not null ,
-  observation_period_end_date		    date		  not null ,
-  period_type_concept_id			      integer		not null
+  observation_period_id				      INT64		not null ,
+  person_id							            INT64		not null ,
+  observation_period_start_DATE		  DATE		  not null ,
+  observation_period_end_DATE		    DATE		  not null ,
+  period_type_concept_id			      INT64		not null
 )
 ;
 
@@ -204,21 +204,21 @@ create table observation_period
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table specimen
 (
-  specimen_id						      integer			not null ,
-  person_id							      integer			not null ,
-  specimen_concept_id				  integer			not null ,
-  specimen_type_concept_id		integer			not null ,
-  specimen_date						    date			  not null ,
-  specimen_datetime					  datetime		null ,
-  quantity							      float			  null ,
-  unit_concept_id					    integer			null ,
-  anatomic_site_concept_id		integer			null ,
-  disease_status_concept_id		integer			null ,
-  specimen_source_id				  varchar(50)	null ,
-  specimen_source_value				varchar(50)	null ,
-  unit_source_value					  varchar(50)	null ,
-  anatomic_site_source_value	varchar(50)	null ,
-  disease_status_source_value varchar(50)	null
+  specimen_id						      INT64			not null ,
+  person_id							      INT64			not null ,
+  specimen_concept_id				  INT64			not null ,
+  specimen_type_concept_id		INT64			not null ,
+  specimen_DATE						    DATE			  not null ,
+  specimen_DATETIME					  DATETIME		null ,
+  quantity							      FLOAT64			  null ,
+  unit_concept_id					    INT64			null ,
+  anatomic_site_concept_id		INT64			null ,
+  disease_status_concept_id		INT64			null ,
+  specimen_source_id				  STRING  	null ,
+  specimen_source_value				STRING  	null ,
+  unit_source_value					  STRING  	null ,
+  anatomic_site_source_value	STRING  	null ,
+  disease_status_source_value STRING  	null
 )
 ;
 
@@ -226,13 +226,13 @@ create table specimen
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table death
 (
-  person_id							  integer			not null ,
-  death_date							date			  not null ,
-  death_datetime					datetime		null ,
-  death_type_concept_id   integer			not null ,
-  cause_concept_id			  integer			null ,
-  cause_source_value			varchar(50)	null,
-  cause_source_concept_id integer			null
+  person_id							  INT64			not null ,
+  death_DATE							DATE			  not null ,
+  death_DATETIME					DATETIME		null ,
+  death_type_concept_id   INT64			not null ,
+  cause_concept_id			  INT64			null ,
+  cause_source_value			STRING  	null,
+  cause_source_concept_id INT64			null
 )
 ;
 
@@ -240,23 +240,23 @@ create table death
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table visit_occurrence
 (
-  visit_occurrence_id			      integer			not null ,
-  person_id						          integer			not null ,
-  visit_concept_id				      integer			not null ,
-  visit_start_date				      date			  not null ,
-  visit_start_datetime				  datetime		null ,
-  visit_end_date					      date			  not null ,
-  visit_end_datetime					  datetime		null ,
-  visit_type_concept_id			    integer			not null ,
-  provider_id					          integer			null,
-  care_site_id					        integer			null,
-  visit_source_value				    varchar(50)	null,
-  visit_source_concept_id		    integer			null ,
-  admitting_source_concept_id	  integer			null ,
-  admitting_source_value		    varchar(50)	null ,
-  discharge_to_concept_id		    integer   	null ,
-  discharge_to_source_value		  varchar(50)	null ,
-  preceding_visit_occurrence_id	integer			null
+  visit_occurrence_id			      INT64			not null ,
+  person_id						          INT64			not null ,
+  visit_concept_id				      INT64			not null ,
+  visit_start_DATE				      DATE			  not null ,
+  visit_start_DATETIME				  DATETIME		null ,
+  visit_end_DATE					      DATE			  not null ,
+  visit_end_DATETIME					  DATETIME		null ,
+  visit_type_concept_id			    INT64			not null ,
+  provider_id					          INT64			null,
+  care_site_id					        INT64			null,
+  visit_source_value				    STRING  	null,
+  visit_source_concept_id		    INT64			null ,
+  admitting_source_concept_id	  INT64			null ,
+  admitting_source_value		    STRING  	null ,
+  discharge_to_concept_id		    INT64   	null ,
+  discharge_to_source_value		  STRING  	null ,
+  preceding_visit_occurrence_id	INT64			null
 )
 ;
 
@@ -264,25 +264,25 @@ create table visit_occurrence
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table visit_detail
 (
-  visit_detail_id             integer     not null ,
-  person_id                   integer     not null ,
-  visit_detail_concept_id     integer     not null ,
-  visit_start_date            date        not null ,
-  visit_start_datetime        datetime   null ,
-  visit_end_date              date        not null ,
-  visit_end_datetime          datetime   null ,
-  visit_type_concept_id       integer     not null ,
-  provider_id                 integer     null ,
-  care_site_id                integer     null ,
-  admitting_source_concept_id integer     null ,
-  discharge_to_concept_id     integer     null ,
-  preceding_visit_detail_id   integer     null ,
-  visit_source_value          varchar(50) null ,
-  visit_source_concept_id     integer     null ,
-  admitting_source_value      varchar(50) null ,
-  discharge_to_source_value   varchar(50) null ,
-  visit_detail_parent_id      integer     null ,
-  visit_occurrence_id         integer     not null
+  visit_detail_id             INT64     not null ,
+  person_id                   INT64     not null ,
+  visit_detail_concept_id     INT64     not null ,
+  visit_start_DATE            DATE        not null ,
+  visit_start_DATETIME        DATETIME   null ,
+  visit_end_DATE              DATE        not null ,
+  visit_end_DATETIME          DATETIME   null ,
+  visit_type_concept_id       INT64     not null ,
+  provider_id                 INT64     null ,
+  care_site_id                INT64     null ,
+  admitting_source_concept_id INT64     null ,
+  discharge_to_concept_id     INT64     null ,
+  preceding_visit_detail_id   INT64     null ,
+  visit_source_value          STRING     null ,
+  visit_source_concept_id     INT64     null ,
+  admitting_source_value      STRING     null ,
+  discharge_to_source_value   STRING     null ,
+  visit_detail_parent_id      INT64     null ,
+  visit_occurrence_id         INT64     not null
 )
 ;
 
@@ -290,20 +290,20 @@ create table visit_detail
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table procedure_occurrence
 (
-  procedure_occurrence_id		  integer			not null ,
-  person_id						        integer			not null ,
-  procedure_concept_id			  integer			not null ,
-  procedure_date				      date			  not null ,
-  procedure_datetime			    datetime		null ,
-  procedure_type_concept_id		integer			not null ,
-  modifier_concept_id			    integer			null ,
-  quantity						        integer			null ,
-  provider_id					        integer			null ,
-  visit_occurrence_id			    integer			null ,
-  visit_detail_id             integer     null ,
-  procedure_source_value		  varchar(50)	null ,
-  procedure_source_concept_id	integer			null ,
-  modifier_source_value		   varchar(50)	null
+  procedure_occurrence_id		  INT64			not null ,
+  person_id						        INT64			not null ,
+  procedure_concept_id			  INT64			not null ,
+  procedure_DATE				      DATE			  not null ,
+  procedure_DATETIME			    DATETIME		null ,
+  procedure_type_concept_id		INT64			not null ,
+  modifier_concept_id			    INT64			null ,
+  quantity						        INT64			null ,
+  provider_id					        INT64			null ,
+  visit_occurrence_id			    INT64			null ,
+  visit_detail_id             INT64     null ,
+  procedure_source_value		  STRING  	null ,
+  procedure_source_concept_id	INT64			null ,
+  modifier_source_value		   STRING   	null
 )
 ;
 
@@ -311,29 +311,29 @@ create table procedure_occurrence
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table drug_exposure
 (
-  drug_exposure_id				      integer			  not null ,
-  person_id						          integer			  not null ,
-  drug_concept_id				        integer			  not null ,
-  drug_exposure_start_date		  date			    not null ,
-  drug_exposure_start_datetime  datetime		  null ,
-  drug_exposure_end_date		    date			    not null ,
-  drug_exposure_end_datetime	  datetime		  null ,
-  verbatim_end_date				      date			    null ,
-  drug_type_concept_id			    integer			  not null ,
-  stop_reason					          varchar(20)		null ,
-  refills						            integer		  	null ,
-  quantity						          float			    null ,
-  days_supply					          integer		  	null ,
-  sig							              varchar(max)	null ,
-  route_concept_id				      integer			  null ,
-  lot_number					          varchar(50)	  null ,
-  provider_id					          integer			  null ,
-  visit_occurrence_id			      integer			  null ,
-  visit_detail_id               integer       null ,
-  drug_source_value				      varchar(50)	  null ,
-  drug_source_concept_id		    integer			  null ,
-  route_source_value			      varchar(50)	  null ,
-  dose_unit_source_value		    varchar(50)	  null
+  drug_exposure_id				      INT64			  not null ,
+  person_id						          INT64			  not null ,
+  drug_concept_id				        INT64			  not null ,
+  drug_exposure_start_DATE		  DATE			    not null ,
+  drug_exposure_start_DATETIME  DATETIME		  null ,
+  drug_exposure_end_DATE		    DATE			    not null ,
+  drug_exposure_end_DATETIME	  DATETIME		  null ,
+  verbatim_end_DATE				      DATE			    null ,
+  drug_type_concept_id			    INT64			  not null ,
+  stop_reason					          STRING  		null ,
+  refills						            INT64		  	null ,
+  quantity						          FLOAT64			    null ,
+  days_supply					          INT64		  	null ,
+  sig							              STRING    	null ,
+  route_concept_id				      INT64			  null ,
+  lot_number					          STRING  	  null ,
+  provider_id					          INT64			  null ,
+  visit_occurrence_id			      INT64			  null ,
+  visit_detail_id               INT64       null ,
+  drug_source_value				      STRING  	  null ,
+  drug_source_concept_id		    INT64			  null ,
+  route_source_value			      STRING  	  null ,
+  dose_unit_source_value		    STRING  	  null
 )
 ;
 
@@ -341,21 +341,21 @@ create table drug_exposure
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table device_exposure
 (
-  device_exposure_id			        integer		  	not null ,
-  person_id						            integer			  not null ,
-  device_concept_id			        	integer			  not null ,
-  device_exposure_start_date	    date			    not null ,
-  device_exposure_start_datetime  datetime		  null ,
-  device_exposure_end_date		    date			    null ,
-  device_exposure_end_datetime    datetime		  null ,
-  device_type_concept_id		      integer			  not null ,
-  unique_device_id			        	varchar(50)		null ,
-  quantity						            integer			  null ,
-  provider_id					            integer			  null ,
-  visit_occurrence_id			        integer			  null ,
-  visit_detail_id                 integer       null ,
-  device_source_value			        varchar(100)	null ,
-  device_source_concept_id		    integer			  null
+  device_exposure_id			        INT64		  	not null ,
+  person_id						            INT64			  not null ,
+  device_concept_id			        	INT64			  not null ,
+  device_exposure_start_DATE	    DATE			    not null ,
+  device_exposure_start_DATETIME  DATETIME		  null ,
+  device_exposure_end_DATE		    DATE			    null ,
+  device_exposure_end_DATETIME    DATETIME		  null ,
+  device_type_concept_id		      INT64			  not null ,
+  unique_device_id			        	STRING  		null ,
+  quantity						            INT64			  null ,
+  provider_id					            INT64			  null ,
+  visit_occurrence_id			        INT64			  null ,
+  visit_detail_id                 INT64       null ,
+  device_source_value			        STRING    	null ,
+  device_source_concept_id		    INT64			  null
 )
 ;
 
@@ -363,22 +363,22 @@ create table device_exposure
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table condition_occurrence
 (
-  condition_occurrence_id		    integer			not null ,
-  person_id						          integer			not null ,
-  condition_concept_id			    integer			not null ,
-  condition_start_date			    date			  not null ,
-  condition_start_datetime		  datetime		null ,
-  condition_end_date			      date			  null ,
-  condition_end_datetime		    datetime		null ,
-  condition_type_concept_id		  integer			not null ,
-  stop_reason					          varchar(20)	null ,
-  provider_id					          integer			null ,
-  visit_occurrence_id			      integer			null ,
-  visit_detail_id               integer     null ,
-  condition_source_value		    varchar(50)	null ,
-  condition_source_concept_id	  integer			null ,
-  condition_status_source_value	varchar(50)	null ,
-  condition_status_concept_id	  integer			null
+  condition_occurrence_id		    INT64			not null ,
+  person_id						          INT64			not null ,
+  condition_concept_id			    INT64			not null ,
+  condition_start_DATE			    DATE			  not null ,
+  condition_start_DATETIME		  DATETIME		null ,
+  condition_end_DATE			      DATE			  null ,
+  condition_end_DATETIME		    DATETIME		null ,
+  condition_type_concept_id		  INT64			not null ,
+  stop_reason					          STRING   	null ,
+  provider_id					          INT64			null ,
+  visit_occurrence_id			      INT64			null ,
+  visit_detail_id               INT64     null ,
+  condition_source_value		    STRING  	null ,
+  condition_source_concept_id	  INT64			null ,
+  condition_status_source_value	STRING  	null ,
+  condition_status_concept_id	  INT64			null
 )
 ;
 
@@ -386,26 +386,26 @@ create table condition_occurrence
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table measurement
 (
-  measurement_id				        integer			not null ,
-  person_id						          integer			not null ,
-  measurement_concept_id		    integer			not null ,
-  measurement_date				      date			  not null ,
-  measurement_datetime          datetime    null ,
-  measurement_time              varchar(10) null ,
-  measurement_type_concept_id	  integer			not null ,
-  operator_concept_id			      integer			null ,
-  value_as_number				        float			  null ,
-  value_as_concept_id			      integer			null ,
-  unit_concept_id				        integer			null ,
-  range_low					          	float			  null ,
-  range_high					          float			  null ,
-  provider_id					          integer			null ,
-  visit_occurrence_id			      integer			null ,
-  visit_detail_id               integer     null ,
-  measurement_source_value		  varchar(50)	null ,
-  measurement_source_concept_id	integer			null ,
-  unit_source_value				      varchar(50)	null ,
-  value_source_value			      varchar(50)	null
+  measurement_id				        INT64			not null ,
+  person_id						          INT64			not null ,
+  measurement_concept_id		    INT64			not null ,
+  measurement_DATE				      DATE			  not null ,
+  measurement_DATETIME          DATETIME    null ,
+  measurement_time              STRING    null ,
+  measurement_type_concept_id	  INT64			not null ,
+  operator_concept_id			      INT64			null ,
+  value_as_number				        FLOAT64			  null ,
+  value_as_concept_id			      INT64			null ,
+  unit_concept_id				        INT64			null ,
+  range_low					          	FLOAT64			  null ,
+  range_high					          FLOAT64			  null ,
+  provider_id					          INT64			null ,
+  visit_occurrence_id			      INT64			null ,
+  visit_detail_id               INT64     null ,
+  measurement_source_value		  STRING  	null ,
+  measurement_source_concept_id	INT64			null ,
+  unit_source_value				      STRING  	null ,
+  value_source_value			      STRING  	null
 )
 ;
 
@@ -413,20 +413,20 @@ create table measurement
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table note
 (
-  note_id						    integer			  not null ,
-  person_id						  integer			  not null ,
-  note_date						  date			    not null ,
-  note_datetime					datetime		  null ,
-  note_type_concept_id	integer			  not null ,
-  note_class_concept_id integer			  not null ,
-  note_title					  varchar(250)	null ,
-  note_text						  varchar(max)  null ,
-  encoding_concept_id		integer			  not null ,
-  language_concept_id		integer			  not null ,
-  provider_id					  integer			  null ,
-  visit_occurrence_id		integer			  null ,
-  visit_detail_id       integer       null ,
-  note_source_value			varchar(50)		null
+  note_id						    INT64			  not null ,
+  person_id						  INT64			  not null ,
+  note_DATE						  DATE			    not null ,
+  note_DATETIME					DATETIME		  null ,
+  note_type_concept_id	INT64			  not null ,
+  note_class_concept_id INT64			  not null ,
+  note_title					  STRING    	null ,
+  note_text						  STRING      null ,
+  encoding_concept_id		INT64			  not null ,
+  language_concept_id		INT64			  not null ,
+  provider_id					  INT64			  null ,
+  visit_occurrence_id		INT64			  null ,
+  visit_detail_id       INT64       null ,
+  note_source_value			STRING  		null
 )
 ;
 
@@ -434,20 +434,20 @@ create table note
 
 create table note_nlp
 (
-  note_nlp_id					        integer			  not null ,
-  note_id						          integer			  not null ,
-  section_concept_id			    integer			  null ,
-  snippet						          varchar(250)	null ,
-  "offset"					          varchar(250)	null ,
-  lexical_variant				      varchar(250)	not null ,
-  note_nlp_concept_id			    integer			  null ,
-  note_nlp_source_concept_id  integer			  null ,
-  nlp_system					        varchar(250)	null ,
-  nlp_date						        date			    not null ,
-  nlp_datetime					      datetime		  null ,
-  term_exists					        varchar(1)		null ,
-  term_temporal					      varchar(50)		null ,
-  term_modifiers				      varchar(2000)	null
+  note_nlp_id					        INT64			  not null ,
+  note_id						          INT64			  not null ,
+  section_concept_id			    INT64			  null ,
+  snippet						          STRING    	null ,
+  "offset"					          STRING    	null ,
+  lexical_variant				      STRING    	not null ,
+  note_nlp_concept_id			    INT64			  null ,
+  note_nlp_source_concept_id  INT64			  null ,
+  nlp_system					        STRING	    null ,
+  nlp_DATE						        DATE			    not null ,
+  nlp_DATETIME					      DATETIME		  null ,
+  term_exists					        STRING   		null ,
+  term_temporal					      STRING   		null ,
+  term_modifiers				      STRING    	null
 )
 ;
 
@@ -455,80 +455,80 @@ create table note_nlp
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table observation
 (
-  observation_id					      integer			not null ,
-  person_id						          integer			not null ,
-  observation_concept_id			  integer			not null ,
-  observation_date				      date			  not null ,
-  observation_datetime				  datetime		null ,
-  observation_type_concept_id	  integer			not null ,
-  value_as_number				        float			  null ,
-  value_as_string				        varchar(60)	null ,
-  value_as_concept_id			      integer			null ,
-  qualifier_concept_id			    integer			null ,
-  unit_concept_id				        integer			null ,
-  provider_id					          integer			null ,
-  visit_occurrence_id			      integer			null ,
-  visit_detail_id               integer     null ,
-  observation_source_value		  varchar(50)	null ,
-  observation_source_concept_id	integer			null ,
-  unit_source_value				      varchar(50)	null ,
-  qualifier_source_value			  varchar(50)	null
+  observation_id					      INT64			not null ,
+  person_id						          INT64			not null ,
+  observation_concept_id			  INT64			not null ,
+  observation_DATE				      DATE			  not null ,
+  observation_DATETIME				  DATETIME		null ,
+  observation_type_concept_id	  INT64			not null ,
+  value_as_number				        FLOAT64			  null ,
+  value_as_string				        STRING   	null ,
+  value_as_concept_id			      INT64			null ,
+  qualifier_concept_id			    INT64			null ,
+  unit_concept_id				        INT64			null ,
+  provider_id					          INT64			null ,
+  visit_occurrence_id			      INT64			null ,
+  visit_detail_id               INT64     null ,
+  observation_source_value		  STRING  	null ,
+  observation_source_concept_id	INT64			null ,
+  unit_source_value				      STRING  	null ,
+  qualifier_source_value			  STRING  	null
 )
 ;
 
 
 create table fact_relationship
 (
-  domain_concept_id_1			integer			not null ,
-  fact_id_1						    integer			not null ,
-  domain_concept_id_2			integer			not null ,
-  fact_id_2						    integer			not null ,
-  relationship_concept_id	integer			not null
+  domain_concept_id_1			INT64			not null ,
+  fact_id_1						    INT64			not null ,
+  domain_concept_id_2			INT64			not null ,
+  fact_id_2						    INT64			not null ,
+  relationship_concept_id	INT64			not null
 )
 ;
 
 
 create table location
 (
-  location_id					  integer			  not null ,
-  address_1						  varchar(50)		null ,
-  address_2						  varchar(50)		null ,
-  city							    varchar(50)		null ,
-  state							    varchar(2)		null ,
-  zip							      varchar(9)		null ,
-  county							  varchar(20)		null ,
-  location_source_value varchar(50)		null
+  location_id					  INT64			  not null ,
+  address_1						  STRING	    	null ,
+  address_2						  STRING    		null ,
+  city							    STRING    		null ,
+  state							    STRING   		null ,
+  zip							      STRING   		null ,
+  county							  STRING    		null ,
+  location_source_value STRING    		null
 )
 ;
 
 
 create table care_site
 (
-  care_site_id						      integer			  not null ,
-  care_site_name						    varchar(255)  null ,
-  place_of_service_concept_id	  integer			  null ,
-  location_id						        integer			  null ,
-  care_site_source_value			  varchar(50)		null ,
-  place_of_service_source_value varchar(50)		null
+  care_site_id						      INT64			  not null ,
+  care_site_name						    STRING       null ,
+  place_of_service_concept_id	  INT64			  null ,
+  location_id						        INT64			  null ,
+  care_site_source_value			  STRING    		null ,
+  place_of_service_source_value STRING    		null
 )
 ;
 
 
 create table provider
 (
-  provider_id					        integer			  not null ,
-  provider_name					      varchar(255)	null ,
-  npi							            varchar(20)		null ,
-  dea							            varchar(20)		null ,
-  specialty_concept_id			  integer			  null ,
-  care_site_id					      integer			  null ,
-  year_of_birth					      integer			  null ,
-  gender_concept_id				    integer			  null ,
-  provider_source_value			  varchar(50)		null ,
-  specialty_source_value			varchar(50)		null ,
-  specialty_source_concept_id	integer			  null ,
-  gender_source_value			    varchar(50)		null ,
-  gender_source_concept_id		integer			  null
+  provider_id					        INT64			  not null ,
+  provider_name					      STRING     	null ,
+  npi							            STRING    		null ,
+  dea							            STRING    		null ,
+  specialty_concept_id			  INT64			  null ,
+  care_site_id					      INT64			  null ,
+  year_of_birth					      INT64			  null ,
+  gender_concept_id				    INT64			  null ,
+  provider_source_value			  STRING    		null ,
+  specialty_source_value			STRING    		null ,
+  specialty_source_concept_id	INT64			  null ,
+  gender_source_value			    STRING    		null ,
+  gender_source_concept_id		INT64			  null
 )
 ;
 
@@ -536,51 +536,51 @@ create table provider
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table payer_plan_period
 (
-  payer_plan_period_id			    integer			  not null ,
-  person_id						          integer			  not null ,
-  payer_plan_period_start_date  date			    not null ,
-  payer_plan_period_end_date		date			    not null ,
-  payer_concept_id              integer       null ,
-  payer_source_value				    varchar(50)	  null ,
-  payer_source_concept_id       integer       null ,
-  plan_concept_id               integer       null ,
-  plan_source_value				      varchar(50)	  null ,
-  plan_source_concept_id        integer       null ,
-  sponsor_concept_id            integer       null ,
-  sponsor_source_value          varchar(50)   null ,
-  sponsor_source_concept_id     integer       null ,
-  family_source_value			      varchar(50)	  null ,
-  stop_reason_concept_id        integer       null ,
-  stop_reason_source_value      varchar(50)   null ,
-  stop_reason_source_concept_id integer       null
+  payer_plan_period_id			    INT64			  not null ,
+  person_id						          INT64			  not null ,
+  payer_plan_period_start_DATE  DATE			    not null ,
+  payer_plan_period_end_DATE		DATE			    not null ,
+  payer_concept_id              INT64       null ,
+  payer_source_value				    STRING    	  null ,
+  payer_source_concept_id       INT64       null ,
+  plan_concept_id               INT64       null ,
+  plan_source_value				      STRING    	  null ,
+  plan_source_concept_id        INT64       null ,
+  sponsor_concept_id            INT64       null ,
+  sponsor_source_value          STRING       null ,
+  sponsor_source_concept_id     INT64       null ,
+  family_source_value			      STRING    	  null ,
+  stop_reason_concept_id        INT64       null ,
+  stop_reason_source_value      STRING       null ,
+  stop_reason_source_concept_id INT64       null
 )
 ;
 
 
 create table cost
 (
-  cost_id					          integer	    not null ,
-  cost_event_id             integer     not null ,
-  cost_domain_id            varchar(20) not null ,
-  cost_type_concept_id      integer     not null ,
-  currency_concept_id			  integer			null ,
-  total_charge						  float			  null ,
-  total_cost						    float			  null ,
-  total_paid						    float			  null ,
-  paid_by_payer					    float			  null ,
-  paid_by_patient						float			  null ,
-  paid_patient_copay				float			  null ,
-  paid_patient_coinsurance  float			  null ,
-  paid_patient_deductible		float			  null ,
-  paid_by_primary						float			  null ,
-  paid_ingredient_cost			float			  null ,
-  paid_dispensing_fee				float			  null ,
-  payer_plan_period_id			integer			null ,
-  amount_allowed		        float			  null ,
-  revenue_code_concept_id		integer			null ,
-  revenue_code_source_value  varchar(50) null,
-  drg_concept_id			      integer		  null,
-  drg_source_value			    varchar(3)	null
+  cost_id					          INT64	    not null ,
+  cost_event_id             INT64     not null ,
+  cost_domain_id            STRING     not null ,
+  cost_type_concept_id      INT64     not null ,
+  currency_concept_id			  INT64			null ,
+  total_charge						  FLOAT64			  null ,
+  total_cost						    FLOAT64			  null ,
+  total_paid						    FLOAT64			  null ,
+  paid_by_payer					    FLOAT64			  null ,
+  paid_by_patient						FLOAT64			  null ,
+  paid_patient_copay				FLOAT64			  null ,
+  paid_patient_coinsurance  FLOAT64			  null ,
+  paid_patient_deductible		FLOAT64			  null ,
+  paid_by_primary						FLOAT64			  null ,
+  paid_ingredient_cost			FLOAT64			  null ,
+  paid_dispensing_fee				FLOAT64			  null ,
+  payer_plan_period_id			INT64			null ,
+  amount_allowed		        FLOAT64			  null ,
+  revenue_code_concept_id		INT64			null ,
+  revenue_code_source_value  STRING     null,
+  drg_concept_id			      INT64		  null,
+  drg_source_value			    STRING   	null
 )
 ;
 
@@ -588,10 +588,10 @@ create table cost
 --HINT DISTRIBUTE_ON_KEY(subject_id)
 create table cohort
 (
-  cohort_definition_id	integer		not null ,
-  subject_id						integer		not null ,
-  cohort_start_date			date			not null ,
-  cohort_end_date				date			not null
+  cohort_definition_id	INT64		not null ,
+  subject_id						INT64		not null ,
+  cohort_start_DATE			DATE			not null ,
+  cohort_end_DATE				DATE			not null
 )
 ;
 
@@ -599,13 +599,13 @@ create table cohort
 --HINT DISTRIBUTE_ON_KEY(subject_id)
 create table cohort_attribute
 (
-  cohort_definition_id		integer		not null ,
-  subject_id						  integer		not null ,
-  cohort_start_date				date			not null ,
-  cohort_end_date				  date			not null ,
-  attribute_definition_id integer		not null ,
-  value_as_number				  float			null ,
-  value_as_concept_id			integer		null
+  cohort_definition_id		INT64		not null ,
+  subject_id						  INT64		not null ,
+  cohort_start_DATE				DATE			not null ,
+  cohort_end_DATE				  DATE			not null ,
+  attribute_definition_id INT64		not null ,
+  value_as_number				  FLOAT64			null ,
+  value_as_concept_id			INT64		null
 )
 ;
 
@@ -613,13 +613,13 @@ create table cohort_attribute
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table drug_era
 (
-  drug_era_id					integer			not null ,
-  person_id						integer			not null ,
-  drug_concept_id			integer			not null ,
-  drug_era_start_date	date			  not null ,
-  drug_era_end_date		date			  not null ,
-  drug_exposure_count	integer			null ,
-  gap_days						integer			null
+  drug_era_id					INT64			not null ,
+  person_id						INT64			not null ,
+  drug_concept_id			INT64			not null ,
+  drug_era_start_DATE	DATE			  not null ,
+  drug_era_end_DATE		DATE			  not null ,
+  drug_exposure_count	INT64			null ,
+  gap_days						INT64			null
 )
 ;
 
@@ -627,13 +627,13 @@ create table drug_era
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table dose_era
 (
-  dose_era_id					  integer			not null ,
-  person_id						  integer			not null ,
-  drug_concept_id				integer			not null ,
-  unit_concept_id				integer			not null ,
-  dose_value						float			  not null ,
-  dose_era_start_date		date			  not null ,
-  dose_era_end_date	    date			  not null
+  dose_era_id					  INT64			not null ,
+  person_id						  INT64			not null ,
+  drug_concept_id				INT64			not null ,
+  unit_concept_id				INT64			not null ,
+  dose_value						FLOAT64			  not null ,
+  dose_era_start_DATE		DATE			  not null ,
+  dose_era_end_DATE	    DATE			  not null
 )
 ;
 
@@ -641,11 +641,11 @@ create table dose_era
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table condition_era
 (
-  condition_era_id				    integer			not null ,
-  person_id						        integer			not null ,
-  condition_concept_id			  integer			not null ,
-  condition_era_start_date		date			  not null ,
-  condition_era_end_date			date			  not null ,
-  condition_occurrence_count	integer			null
+  condition_era_id				    INT64			not null ,
+  person_id						        INT64			not null ,
+  condition_concept_id			  INT64			not null ,
+  condition_era_start_DATE		DATE			  not null ,
+  condition_era_end_DATE			DATE			  not null ,
+  condition_occurrence_count	INT64			null
 )
 ;

--- a/BigQuery/OMOP CDM bigquery ddl.txt
+++ b/BigQuery/OMOP CDM bigquery ddl.txt
@@ -1,14 +1,15 @@
+#standardsql
 create table concept (
   concept_id			    INT64			  not null ,
   concept_name			  STRING     	not null ,
   domain_id				    STRING   		not null ,
   vocabulary_id			  STRING   		not null ,
   concept_class_id		STRING  		not null ,
-  standard_concept		STRING  		null ,
+  standard_concept		STRING  		         ,
   concept_code			  STRING  		not null ,
   valid_start_DATE		DATE			  not null ,
   valid_end_DATE		  DATE			  not null ,
-  invalid_reason		  STRING  		null
+  invalid_reason		  STRING  		
 )
 ;
 
@@ -17,7 +18,7 @@ create table vocabulary (
   vocabulary_id			    STRING   		not null,
   vocabulary_name		    STRING     	not null,
   vocabulary_reference	STRING     	not null,
-  vocabulary_version	  STRING     	null,
+  vocabulary_version	  STRING     	        ,
   vocabulary_concept_id	INT64			  not null
 )
 ;
@@ -45,7 +46,7 @@ create table concept_relationship (
   relationship_id		STRING  	not null,
   valid_start_DATE	DATE			not null,
   valid_end_DATE		DATE			not null,
-  invalid_reason		STRING  	null
+  invalid_reason		STRING  	
   )
 ;
 
@@ -82,12 +83,12 @@ create table source_to_concept_map (
   source_code				      STRING  		not null,
   source_concept_id			  INT64			  not null,
   source_vocabulary_id		STRING  		not null,
-  source_code_description	STRING    	null,
+  source_code_description	STRING    	        ,
   target_concept_id			  INT64			  not null,
   target_vocabulary_id		STRING  		not null,
   valid_start_DATE			  DATE		    not null,
   valid_end_DATE			    DATE		    not null,
-  invalid_reason			    STRING  		null
+  invalid_reason			    STRING  		
 )
 ;
 
@@ -97,16 +98,16 @@ create table source_to_concept_map (
 create table drug_strength (
   drug_concept_id				      INT64		  not null,
   ingredient_concept_id			  INT64		  not null,
-  amount_value					      FLOAT64		    null,
-  amount_unit_concept_id		  INT64		  null,
-  numerator_value				      FLOAT64		    null,
-  numerator_unit_concept_id		INT64		  null,
-  denominator_value				    FLOAT64		    null,
-  denominator_unit_concept_id	INT64		  null,
-  box_size						        INT64		  null,
-  valid_start_DATE				    DATE		    not null,
-  valid_end_DATE				      DATE		    not null,
-  invalid_reason				      STRING     null
+  amount_value					      FLOAT64		        ,
+  amount_unit_concept_id		  INT64		          ,
+  numerator_value				      FLOAT64		        ,
+  numerator_unit_concept_id		INT64		          ,
+  denominator_value				    FLOAT64		        ,
+  denominator_unit_concept_id	INT64		          ,
+  box_size						        INT64		          ,
+  valid_start_DATE				    DATE		   not null,
+  valid_end_DATE				      DATE		   not null,
+  invalid_reason				      STRING     
 )
 ;
 
@@ -115,11 +116,11 @@ create table drug_strength (
 create table cohort_definition (
   cohort_definition_id				    INT64			  not null,
   cohort_definition_name			    STRING    	not null,
-  cohort_definition_description		STRING    	null,
+  cohort_definition_description		STRING    	        ,
   definition_type_concept_id		  INT64			  not null,
-  cohort_definition_syntax			  STRING     	null,
+  cohort_definition_syntax			  STRING     	        ,
   subject_concept_id				      INT64			  not null,
-  cohort_initiation_DATE			    DATE			    null
+  cohort_initiation_DATE			    DATE			  
 )
 ;
 
@@ -127,9 +128,9 @@ create table cohort_definition (
 create table attribute_definition (
   attribute_definition_id		  INT64			  not null,
   attribute_name				      STRING    	not null,
-  attribute_description			  STRING    	null,
+  attribute_description			  STRING    	        ,
   attribute_type_concept_id		INT64			  not null,
-  attribute_syntax				    STRING    	null
+  attribute_syntax				    STRING    	
 )
 ;
 
@@ -137,15 +138,15 @@ create table attribute_definition (
 create table cdm_source
 (
   cdm_source_name					        STRING      	not null ,
-  cdm_source_abbreviation			    STRING    		null ,
-  cdm_holder							        STRING      	null ,
-  source_description					    STRING      	null ,
-  source_documentation_reference	STRING      	null ,
-  cdm_etl_reference					      STRING      	null ,
-  source_release_DATE				      DATE			    null ,
-  cdm_release_DATE					      DATE			    null ,
-  cdm_version						          STRING    		null ,
-  vocabulary_version					    STRING    		null
+  cdm_source_abbreviation			    STRING    		     ,
+  cdm_holder							        STRING      	     ,
+  source_description					    STRING      	     ,
+  source_documentation_reference	STRING      	     ,
+  cdm_etl_reference					      STRING      	     ,
+  source_release_DATE				      DATE			         ,
+  cdm_release_DATE					      DATE			         ,
+  cdm_version						          STRING    		     ,
+  vocabulary_version					    STRING    		
 )
 ;
 
@@ -155,10 +156,10 @@ create table metadata
   metadata_concept_id       INT64       not null ,
   metadata_type_concept_id  INT64       not null ,
   name                      STRING      not null ,
-  value_as_string           STRING      null ,
-  value_as_concept_id       INT64       null ,
-  metadata_DATE             DATE          null ,
-  metadata_DATETIME         DATETIME      null
+  value_as_string           STRING               ,
+  value_as_concept_id       INT64                ,
+  metadata_DATE             DATE                 ,
+  metadata_DATETIME         DATETIME      
 )
 ;
 
@@ -170,21 +171,21 @@ create table person
   person_id						        INT64	  	not null ,
   gender_concept_id				    INT64	  	not null ,
   year_of_birth					      INT64	  	not null ,
-  month_of_birth				      INT64	  	null,
-  day_of_birth					      INT64	  	null,
-  birth_DATETIME				      DATETIME	  null,
+  month_of_birth				      INT64	  	         ,
+  day_of_birth					      INT64	  	         ,
+  birth_DATETIME				      DATETIME	         ,
   race_concept_id				      INT64		  not null,
   ethnicity_concept_id			  INT64	  	not null,
-  location_id					        INT64		  null,
-  provider_id					        INT64		  null,
-  care_site_id					      INT64		  null,
-  person_source_value			    STRING    null,
-  gender_source_value			    STRING    null,
-  gender_source_concept_id	  INT64		  null,
-  race_source_value				    STRING    null,
-  race_source_concept_id		  INT64		  null,
-  ethnicity_source_value		  STRING    null,
-  ethnicity_source_concept_id	INT64		  null
+  location_id					        INT64		           ,
+  provider_id					        INT64		           ,
+  care_site_id					      INT64		           ,
+  person_source_value			    STRING             ,
+  gender_source_value			    STRING             ,
+  gender_source_concept_id	  INT64		           ,
+  race_source_value				    STRING             ,
+  race_source_concept_id		  INT64		           ,
+  ethnicity_source_value		  STRING             ,
+  ethnicity_source_concept_id	INT64		  
 )
 ;
 
@@ -194,8 +195,8 @@ create table observation_period
 (
   observation_period_id				      INT64		not null ,
   person_id							            INT64		not null ,
-  observation_period_start_DATE		  DATE		  not null ,
-  observation_period_end_DATE		    DATE		  not null ,
+  observation_period_start_DATE		  DATE		not null ,
+  observation_period_end_DATE		    DATE		not null ,
   period_type_concept_id			      INT64		not null
 )
 ;
@@ -208,17 +209,17 @@ create table specimen
   person_id							      INT64			not null ,
   specimen_concept_id				  INT64			not null ,
   specimen_type_concept_id		INT64			not null ,
-  specimen_DATE						    DATE			  not null ,
-  specimen_DATETIME					  DATETIME		null ,
-  quantity							      FLOAT64			  null ,
-  unit_concept_id					    INT64			null ,
-  anatomic_site_concept_id		INT64			null ,
-  disease_status_concept_id		INT64			null ,
-  specimen_source_id				  STRING  	null ,
-  specimen_source_value				STRING  	null ,
-  unit_source_value					  STRING  	null ,
-  anatomic_site_source_value	STRING  	null ,
-  disease_status_source_value STRING  	null
+  specimen_DATE						    DATE			not null ,
+  specimen_DATETIME					  DATETIME	      	 ,
+  quantity							      FLOAT64			       ,
+  unit_concept_id					    INT64			         ,
+  anatomic_site_concept_id		INT64			         ,
+  disease_status_concept_id		INT64			         ,
+  specimen_source_id				  STRING  	         ,
+  specimen_source_value				STRING  	         ,
+  unit_source_value					  STRING  	         ,
+  anatomic_site_source_value	STRING  	         ,
+  disease_status_source_value STRING  	
 )
 ;
 
@@ -227,12 +228,12 @@ create table specimen
 create table death
 (
   person_id							  INT64			not null ,
-  death_DATE							DATE			  not null ,
-  death_DATETIME					DATETIME		null ,
+  death_DATE							DATE			not null ,
+  death_DATETIME					DATETIME	      	 ,
   death_type_concept_id   INT64			not null ,
-  cause_concept_id			  INT64			null ,
-  cause_source_value			STRING  	null,
-  cause_source_concept_id INT64			null
+  cause_concept_id			  INT64			         ,
+  cause_source_value			STRING  	         ,
+  cause_source_concept_id INT64			
 )
 ;
 
@@ -243,20 +244,20 @@ create table visit_occurrence
   visit_occurrence_id			      INT64			not null ,
   person_id						          INT64			not null ,
   visit_concept_id				      INT64			not null ,
-  visit_start_DATE				      DATE			  not null ,
-  visit_start_DATETIME				  DATETIME		null ,
-  visit_end_DATE					      DATE			  not null ,
-  visit_end_DATETIME					  DATETIME		null ,
+  visit_start_DATE				      DATE			not null ,
+  visit_start_DATETIME				  DATETIME	         ,
+  visit_end_DATE					      DATE			not null ,
+  visit_end_DATETIME					  DATETIME		       ,
   visit_type_concept_id			    INT64			not null ,
-  provider_id					          INT64			null,
-  care_site_id					        INT64			null,
-  visit_source_value				    STRING  	null,
-  visit_source_concept_id		    INT64			null ,
-  admitting_source_concept_id	  INT64			null ,
-  admitting_source_value		    STRING  	null ,
-  discharge_to_concept_id		    INT64   	null ,
-  discharge_to_source_value		  STRING  	null ,
-  preceding_visit_occurrence_id	INT64			null
+  provider_id					          INT64			         ,
+  care_site_id					        INT64			         ,
+  visit_source_value				    STRING  	         ,
+  visit_source_concept_id		    INT64			         ,
+  admitting_source_concept_id	  INT64			         ,
+  admitting_source_value		    STRING  	         ,
+  discharge_to_concept_id		    INT64   	         ,
+  discharge_to_source_value		  STRING  	         ,
+  preceding_visit_occurrence_id	INT64			
 )
 ;
 
@@ -267,21 +268,21 @@ create table visit_detail
   visit_detail_id             INT64     not null ,
   person_id                   INT64     not null ,
   visit_detail_concept_id     INT64     not null ,
-  visit_start_DATE            DATE        not null ,
-  visit_start_DATETIME        DATETIME   null ,
-  visit_end_DATE              DATE        not null ,
-  visit_end_DATETIME          DATETIME   null ,
+  visit_start_DATE            DATE      not null ,
+  visit_start_DATETIME        DATETIME           ,
+  visit_end_DATE              DATE      not null ,
+  visit_end_DATETIME          DATETIME           ,
   visit_type_concept_id       INT64     not null ,
-  provider_id                 INT64     null ,
-  care_site_id                INT64     null ,
-  admitting_source_concept_id INT64     null ,
-  discharge_to_concept_id     INT64     null ,
-  preceding_visit_detail_id   INT64     null ,
-  visit_source_value          STRING     null ,
-  visit_source_concept_id     INT64     null ,
-  admitting_source_value      STRING     null ,
-  discharge_to_source_value   STRING     null ,
-  visit_detail_parent_id      INT64     null ,
+  provider_id                 INT64              ,
+  care_site_id                INT64              ,
+  admitting_source_concept_id INT64              ,
+  discharge_to_concept_id     INT64              ,
+  preceding_visit_detail_id   INT64              ,
+  visit_source_value          STRING             ,
+  visit_source_concept_id     INT64              ,
+  admitting_source_value      STRING             ,
+  discharge_to_source_value   STRING             ,
+  visit_detail_parent_id      INT64              ,
   visit_occurrence_id         INT64     not null
 )
 ;
@@ -293,17 +294,17 @@ create table procedure_occurrence
   procedure_occurrence_id		  INT64			not null ,
   person_id						        INT64			not null ,
   procedure_concept_id			  INT64			not null ,
-  procedure_DATE				      DATE			  not null ,
-  procedure_DATETIME			    DATETIME		null ,
+  procedure_DATE				      DATE			not null ,
+  procedure_DATETIME			    DATETIME	  	     ,
   procedure_type_concept_id		INT64			not null ,
-  modifier_concept_id			    INT64			null ,
-  quantity						        INT64			null ,
-  provider_id					        INT64			null ,
-  visit_occurrence_id			    INT64			null ,
-  visit_detail_id             INT64     null ,
-  procedure_source_value		  STRING  	null ,
-  procedure_source_concept_id	INT64			null ,
-  modifier_source_value		   STRING   	null
+  modifier_concept_id			    INT64			         ,
+  quantity						        INT64			         ,
+  provider_id					        INT64			         ,
+  visit_occurrence_id			    INT64			         ,
+  visit_detail_id             INT64              ,
+  procedure_source_value		  STRING  	         ,
+  procedure_source_concept_id	INT64			         ,
+  modifier_source_value		   STRING   	  
 )
 ;
 
@@ -314,26 +315,26 @@ create table drug_exposure
   drug_exposure_id				      INT64			  not null ,
   person_id						          INT64			  not null ,
   drug_concept_id				        INT64			  not null ,
-  drug_exposure_start_DATE		  DATE			    not null ,
-  drug_exposure_start_DATETIME  DATETIME		  null ,
-  drug_exposure_end_DATE		    DATE			    not null ,
-  drug_exposure_end_DATETIME	  DATETIME		  null ,
-  verbatim_end_DATE				      DATE			    null ,
+  drug_exposure_start_DATE		  DATE			  not null ,
+  drug_exposure_start_DATETIME  DATETIME		         ,
+  drug_exposure_end_DATE		    DATE			  not null ,
+  drug_exposure_end_DATETIME	  DATETIME		         ,
+  verbatim_end_DATE				      DATE			           ,
   drug_type_concept_id			    INT64			  not null ,
-  stop_reason					          STRING  		null ,
-  refills						            INT64		  	null ,
-  quantity						          FLOAT64			    null ,
-  days_supply					          INT64		  	null ,
-  sig							              STRING    	null ,
-  route_concept_id				      INT64			  null ,
-  lot_number					          STRING  	  null ,
-  provider_id					          INT64			  null ,
-  visit_occurrence_id			      INT64			  null ,
-  visit_detail_id               INT64       null ,
-  drug_source_value				      STRING  	  null ,
-  drug_source_concept_id		    INT64			  null ,
-  route_source_value			      STRING  	  null ,
-  dose_unit_source_value		    STRING  	  null
+  stop_reason					          STRING  		         ,
+  refills						            INT64		  	         ,
+  quantity						          FLOAT64			         ,
+  days_supply					          INT64		  	         ,
+  sig							              STRING               ,
+  route_concept_id				      INT64			           ,
+  lot_number					          STRING  	           ,
+  provider_id					          INT64			           ,
+  visit_occurrence_id			      INT64			           ,
+  visit_detail_id               INT64                ,
+  drug_source_value				      STRING  	           ,
+  drug_source_concept_id		    INT64			           ,
+  route_source_value			      STRING  	           ,
+  dose_unit_source_value		    STRING  	  
 )
 ;
 
@@ -344,18 +345,18 @@ create table device_exposure
   device_exposure_id			        INT64		  	not null ,
   person_id						            INT64			  not null ,
   device_concept_id			        	INT64			  not null ,
-  device_exposure_start_DATE	    DATE			    not null ,
-  device_exposure_start_DATETIME  DATETIME		  null ,
-  device_exposure_end_DATE		    DATE			    null ,
-  device_exposure_end_DATETIME    DATETIME		  null ,
+  device_exposure_start_DATE	    DATE			  not null ,
+  device_exposure_start_DATETIME  DATETIME		         ,
+  device_exposure_end_DATE		    DATE			           ,
+  device_exposure_end_DATETIME    DATETIME		         ,
   device_type_concept_id		      INT64			  not null ,
-  unique_device_id			        	STRING  		null ,
-  quantity						            INT64			  null ,
-  provider_id					            INT64			  null ,
-  visit_occurrence_id			        INT64			  null ,
-  visit_detail_id                 INT64       null ,
-  device_source_value			        STRING    	null ,
-  device_source_concept_id		    INT64			  null
+  unique_device_id			        	STRING  		         ,
+  quantity						            INT64			           ,
+  provider_id					            INT64			           ,
+  visit_occurrence_id			        INT64			           ,
+  visit_detail_id                 INT64                ,
+  device_source_value			        STRING    	         ,
+  device_source_concept_id		    INT64			  
 )
 ;
 
@@ -366,19 +367,19 @@ create table condition_occurrence
   condition_occurrence_id		    INT64			not null ,
   person_id						          INT64			not null ,
   condition_concept_id			    INT64			not null ,
-  condition_start_DATE			    DATE			  not null ,
-  condition_start_DATETIME		  DATETIME		null ,
-  condition_end_DATE			      DATE			  null ,
-  condition_end_DATETIME		    DATETIME		null ,
+  condition_start_DATE			    DATE			not null ,
+  condition_start_DATETIME		  DATETIME		       ,
+  condition_end_DATE			      DATE			         ,
+  condition_end_DATETIME		    DATETIME		       ,
   condition_type_concept_id		  INT64			not null ,
-  stop_reason					          STRING   	null ,
-  provider_id					          INT64			null ,
-  visit_occurrence_id			      INT64			null ,
-  visit_detail_id               INT64     null ,
-  condition_source_value		    STRING  	null ,
-  condition_source_concept_id	  INT64			null ,
-  condition_status_source_value	STRING  	null ,
-  condition_status_concept_id	  INT64			null
+  stop_reason					          STRING   	         ,
+  provider_id					          INT64			         ,
+  visit_occurrence_id			      INT64			         ,
+  visit_detail_id               INT64              ,
+  condition_source_value		    STRING  	         ,
+  condition_source_concept_id	  INT64			         ,
+  condition_status_source_value	STRING             ,
+  condition_status_concept_id	  INT64			
 )
 ;
 
@@ -389,23 +390,23 @@ create table measurement
   measurement_id				        INT64			not null ,
   person_id						          INT64			not null ,
   measurement_concept_id		    INT64			not null ,
-  measurement_DATE				      DATE			  not null ,
-  measurement_DATETIME          DATETIME    null ,
-  measurement_time              STRING    null ,
+  measurement_DATE				      DATE			not null ,
+  measurement_DATETIME          DATETIME           ,
+  measurement_time              STRING             ,
   measurement_type_concept_id	  INT64			not null ,
-  operator_concept_id			      INT64			null ,
-  value_as_number				        FLOAT64			  null ,
-  value_as_concept_id			      INT64			null ,
-  unit_concept_id				        INT64			null ,
-  range_low					          	FLOAT64			  null ,
-  range_high					          FLOAT64			  null ,
-  provider_id					          INT64			null ,
-  visit_occurrence_id			      INT64			null ,
-  visit_detail_id               INT64     null ,
-  measurement_source_value		  STRING  	null ,
-  measurement_source_concept_id	INT64			null ,
-  unit_source_value				      STRING  	null ,
-  value_source_value			      STRING  	null
+  operator_concept_id			      INT64			         ,
+  value_as_number				        FLOAT64			       ,
+  value_as_concept_id			      INT64			         ,
+  unit_concept_id				        INT64			         ,
+  range_low					          	FLOAT64			       ,
+  range_high					          FLOAT64			       ,
+  provider_id					          INT64			         ,
+  visit_occurrence_id			      INT64			         ,
+  visit_detail_id               INT64              ,
+  measurement_source_value		  STRING             ,
+  measurement_source_concept_id	INT64			         ,
+  unit_source_value				      STRING  	         ,
+  value_source_value			      STRING  	
 )
 ;
 
@@ -415,18 +416,18 @@ create table note
 (
   note_id						    INT64			  not null ,
   person_id						  INT64			  not null ,
-  note_DATE						  DATE			    not null ,
-  note_DATETIME					DATETIME		  null ,
+  note_DATE						  DATE			  not null ,
+  note_DATETIME					DATETIME	           ,
   note_type_concept_id	INT64			  not null ,
   note_class_concept_id INT64			  not null ,
-  note_title					  STRING    	null ,
-  note_text						  STRING      null ,
+  note_title					  STRING    	         ,
+  note_text						  STRING               ,
   encoding_concept_id		INT64			  not null ,
   language_concept_id		INT64			  not null ,
-  provider_id					  INT64			  null ,
-  visit_occurrence_id		INT64			  null ,
-  visit_detail_id       INT64       null ,
-  note_source_value			STRING  		null
+  provider_id					  INT64			           ,
+  visit_occurrence_id		INT64			           ,
+  visit_detail_id       INT64                ,
+  note_source_value			STRING  		
 )
 ;
 
@@ -434,20 +435,20 @@ create table note
 
 create table note_nlp
 (
-  note_nlp_id					        INT64			  not null ,
-  note_id						          INT64			  not null ,
-  section_concept_id			    INT64			  null ,
-  snippet						          STRING    	null ,
-  "offset"					          STRING    	null ,
+  note_nlp_id					        INT64			           ,
+  note_id						          INT64			           ,
+  section_concept_id			    INT64			           ,
+  snippet						          STRING    	         ,
+  "offset"					          STRING    	         ,
   lexical_variant				      STRING    	not null ,
-  note_nlp_concept_id			    INT64			  null ,
-  note_nlp_source_concept_id  INT64			  null ,
-  nlp_system					        STRING	    null ,
-  nlp_DATE						        DATE			    not null ,
-  nlp_DATETIME					      DATETIME		  null ,
-  term_exists					        STRING   		null ,
-  term_temporal					      STRING   		null ,
-  term_modifiers				      STRING    	null
+  note_nlp_concept_id			    INT64			           ,
+  note_nlp_source_concept_id  INT64			           ,
+  nlp_system					        STRING	             ,
+  nlp_DATE						        DATE			  not null ,
+  nlp_DATETIME					      DATETIME		         ,
+  term_exists					        STRING   		         ,
+  term_temporal					      STRING   		         ,
+  term_modifiers				      STRING    	
 )
 ;
 
@@ -458,21 +459,21 @@ create table observation
   observation_id					      INT64			not null ,
   person_id						          INT64			not null ,
   observation_concept_id			  INT64			not null ,
-  observation_DATE				      DATE			  not null ,
-  observation_DATETIME				  DATETIME		null ,
+  observation_DATE				      DATE			not null ,
+  observation_DATETIME				  DATETIME		       ,
   observation_type_concept_id	  INT64			not null ,
-  value_as_number				        FLOAT64			  null ,
-  value_as_string				        STRING   	null ,
-  value_as_concept_id			      INT64			null ,
-  qualifier_concept_id			    INT64			null ,
-  unit_concept_id				        INT64			null ,
-  provider_id					          INT64			null ,
-  visit_occurrence_id			      INT64			null ,
-  visit_detail_id               INT64     null ,
-  observation_source_value		  STRING  	null ,
-  observation_source_concept_id	INT64			null ,
-  unit_source_value				      STRING  	null ,
-  qualifier_source_value			  STRING  	null
+  value_as_number				        FLOAT64			   ,
+  value_as_string				        STRING   	     ,
+  value_as_concept_id			      INT64			     ,
+  qualifier_concept_id			    INT64			     ,
+  unit_concept_id				        INT64			     ,
+  provider_id					          INT64			     ,
+  visit_occurrence_id			      INT64			     ,
+  visit_detail_id               INT64          ,
+  observation_source_value		  STRING  	     ,
+  observation_source_concept_id	INT64			     ,
+  unit_source_value				      STRING  	     ,
+  qualifier_source_value			  STRING  	
 )
 ;
 
@@ -490,14 +491,14 @@ create table fact_relationship
 
 create table location
 (
-  location_id					  INT64			  not null ,
-  address_1						  STRING	    	null ,
-  address_2						  STRING    		null ,
-  city							    STRING    		null ,
-  state							    STRING   		null ,
-  zip							      STRING   		null ,
-  county							  STRING    		null ,
-  location_source_value STRING    		null
+  location_id					  INT64			not null ,
+  address_1						  STRING	           ,
+  address_2						  STRING    		     ,
+  city							    STRING    		     ,
+  state							    STRING   		       ,
+  zip							      STRING   	         ,
+  county							  STRING    		     ,
+  location_source_value STRING    		
 )
 ;
 
@@ -505,11 +506,11 @@ create table location
 create table care_site
 (
   care_site_id						      INT64			  not null ,
-  care_site_name						    STRING       null ,
-  place_of_service_concept_id	  INT64			  null ,
-  location_id						        INT64			  null ,
-  care_site_source_value			  STRING    		null ,
-  place_of_service_source_value STRING    		null
+  care_site_name						    STRING               ,
+  place_of_service_concept_id	  INT64			           ,
+  location_id						        INT64			           ,
+  care_site_source_value			  STRING    		       ,
+  place_of_service_source_value STRING    		
 )
 ;
 
@@ -517,18 +518,18 @@ create table care_site
 create table provider
 (
   provider_id					        INT64			  not null ,
-  provider_name					      STRING     	null ,
-  npi							            STRING    		null ,
-  dea							            STRING    		null ,
-  specialty_concept_id			  INT64			  null ,
-  care_site_id					      INT64			  null ,
-  year_of_birth					      INT64			  null ,
-  gender_concept_id				    INT64			  null ,
-  provider_source_value			  STRING    		null ,
-  specialty_source_value			STRING    		null ,
-  specialty_source_concept_id	INT64			  null ,
-  gender_source_value			    STRING    		null ,
-  gender_source_concept_id		INT64			  null
+  provider_name					      STRING     	         ,
+  npi							            STRING    	         ,
+  dea							            STRING    		       ,
+  specialty_concept_id			  INT64			           ,
+  care_site_id					      INT64			           ,
+  year_of_birth					      INT64			           ,
+  gender_concept_id				    INT64			           ,
+  provider_source_value			  STRING    		       ,
+  specialty_source_value			STRING    		       ,
+  specialty_source_concept_id	INT64			           ,
+  gender_source_value			    STRING    		       ,
+  gender_source_concept_id		INT64			  
 )
 ;
 
@@ -536,23 +537,23 @@ create table provider
 --HINT DISTRIBUTE_ON_KEY(person_id)
 create table payer_plan_period
 (
-  payer_plan_period_id			    INT64			  not null ,
-  person_id						          INT64			  not null ,
-  payer_plan_period_start_DATE  DATE			    not null ,
-  payer_plan_period_end_DATE		DATE			    not null ,
-  payer_concept_id              INT64       null ,
-  payer_source_value				    STRING    	  null ,
-  payer_source_concept_id       INT64       null ,
-  plan_concept_id               INT64       null ,
-  plan_source_value				      STRING    	  null ,
-  plan_source_concept_id        INT64       null ,
-  sponsor_concept_id            INT64       null ,
-  sponsor_source_value          STRING       null ,
-  sponsor_source_concept_id     INT64       null ,
-  family_source_value			      STRING    	  null ,
-  stop_reason_concept_id        INT64       null ,
-  stop_reason_source_value      STRING       null ,
-  stop_reason_source_concept_id INT64       null
+  payer_plan_period_id			    INT64			not null ,
+  person_id						          INT64			not null ,
+  payer_plan_period_start_DATE  DATE			not null ,
+  payer_plan_period_end_DATE		DATE			not null ,
+  payer_concept_id              INT64              ,
+  payer_source_value				    STRING    	       ,
+  payer_source_concept_id       INT64              ,
+  plan_concept_id               INT64              ,
+  plan_source_value				      STRING    	       ,
+  plan_source_concept_id        INT64              ,
+  sponsor_concept_id            INT64              ,
+  sponsor_source_value          STRING             ,
+  sponsor_source_concept_id     INT64              ,
+  family_source_value			      STRING    	       ,
+  stop_reason_concept_id        INT64              ,
+  stop_reason_source_value      STRING             ,
+  stop_reason_source_concept_id INT64       
 )
 ;
 
@@ -561,26 +562,26 @@ create table cost
 (
   cost_id					          INT64	    not null ,
   cost_event_id             INT64     not null ,
-  cost_domain_id            STRING     not null ,
+  cost_domain_id            STRING    not null ,
   cost_type_concept_id      INT64     not null ,
-  currency_concept_id			  INT64			null ,
-  total_charge						  FLOAT64			  null ,
-  total_cost						    FLOAT64			  null ,
-  total_paid						    FLOAT64			  null ,
-  paid_by_payer					    FLOAT64			  null ,
-  paid_by_patient						FLOAT64			  null ,
-  paid_patient_copay				FLOAT64			  null ,
-  paid_patient_coinsurance  FLOAT64			  null ,
-  paid_patient_deductible		FLOAT64			  null ,
-  paid_by_primary						FLOAT64			  null ,
-  paid_ingredient_cost			FLOAT64			  null ,
-  paid_dispensing_fee				FLOAT64			  null ,
-  payer_plan_period_id			INT64			null ,
-  amount_allowed		        FLOAT64			  null ,
-  revenue_code_concept_id		INT64			null ,
-  revenue_code_source_value  STRING     null,
-  drg_concept_id			      INT64		  null,
-  drg_source_value			    STRING   	null
+  currency_concept_id			  INT64			         ,
+  total_charge						  FLOAT64			       ,
+  total_cost						    FLOAT64			       ,
+  total_paid						    FLOAT64			       ,
+  paid_by_payer					    FLOAT64			       ,
+  paid_by_patient						FLOAT64			       ,
+  paid_patient_copay				FLOAT64			       ,
+  paid_patient_coinsurance  FLOAT64			       ,
+  paid_patient_deductible		FLOAT64			       ,
+  paid_by_primary						FLOAT64			       ,
+  paid_ingredient_cost			FLOAT64			       ,
+  paid_dispensing_fee				FLOAT64			       ,
+  payer_plan_period_id			INT64			         ,
+  amount_allowed		        FLOAT64			       ,
+  revenue_code_concept_id		INT64			         ,
+  revenue_code_source_value  STRING            ,
+  drg_concept_id			      INT64		           ,
+  drg_source_value			    STRING   	
 )
 ;
 
@@ -599,13 +600,13 @@ create table cohort
 --HINT DISTRIBUTE_ON_KEY(subject_id)
 create table cohort_attribute
 (
-  cohort_definition_id		INT64		not null ,
-  subject_id						  INT64		not null ,
+  cohort_definition_id		INT64		  not null ,
+  subject_id						  INT64		  not null ,
   cohort_start_DATE				DATE			not null ,
   cohort_end_DATE				  DATE			not null ,
-  attribute_definition_id INT64		not null ,
-  value_as_number				  FLOAT64			null ,
-  value_as_concept_id			INT64		null
+  attribute_definition_id INT64		  not null ,
+  value_as_number				  FLOAT64			       ,
+  value_as_concept_id			INT64		
 )
 ;
 
@@ -616,10 +617,10 @@ create table drug_era
   drug_era_id					INT64			not null ,
   person_id						INT64			not null ,
   drug_concept_id			INT64			not null ,
-  drug_era_start_DATE	DATE			  not null ,
-  drug_era_end_DATE		DATE			  not null ,
-  drug_exposure_count	INT64			null ,
-  gap_days						INT64			null
+  drug_era_start_DATE	DATE			not null ,
+  drug_era_end_DATE		DATE		  not null ,
+  drug_exposure_count	INT64	             ,
+  gap_days						INT64			
 )
 ;
 
@@ -631,9 +632,9 @@ create table dose_era
   person_id						  INT64			not null ,
   drug_concept_id				INT64			not null ,
   unit_concept_id				INT64			not null ,
-  dose_value						FLOAT64			  not null ,
-  dose_era_start_DATE		DATE			  not null ,
-  dose_era_end_DATE	    DATE			  not null
+  dose_value						FLOAT64		not null ,
+  dose_era_start_DATE		DATE			not null ,
+  dose_era_end_DATE	    DATE			not null
 )
 ;
 
@@ -644,8 +645,8 @@ create table condition_era
   condition_era_id				    INT64			not null ,
   person_id						        INT64			not null ,
   condition_concept_id			  INT64			not null ,
-  condition_era_start_DATE		DATE			  not null ,
-  condition_era_end_DATE			DATE			  not null ,
-  condition_occurrence_count	INT64			null
+  condition_era_start_DATE		DATE			not null ,
+  condition_era_end_DATE			DATE			not null ,
+  condition_occurrence_count	INT64			
 )
 ;


### PR DESCRIPTION
Changed data types for Google BigQuery compatibility in Google's Standard SQL.
VARCHAR, INT, FLOAT datatypes are not supported in BigQuery.

See: #168 

