### PR TITLE
Fixes issue #173. The proper way to allow reserve words in Impala is …

### DIFF
--- a/Impala/OMOP CDM impala ddl.txt
+++ b/Impala/OMOP CDM impala ddl.txt
@@ -374,7 +374,7 @@ CREATE TABLE cdm_source
 
 
 
-CREATE TABLE "metadata"
+CREATE TABLE `metadata`
 (
 
     metadata_concept_id INTEGER,
@@ -903,7 +903,7 @@ CREATE TABLE note_nlp
 
     snippet VARCHAR(250),
 
-    "offset" VARCHAR(250),
+    `offset` VARCHAR(250),
 
     lexical_variant VARCHAR(250),
 
@@ -1008,7 +1008,7 @@ Standardized health system data
 
 
 
-CREATE TABLE "location"
+CREATE TABLE `location`
 (
 
     location_id INTEGER,


### PR DESCRIPTION
…to use back ticks.