### PR TITLE
Fix in postgres readme

### DIFF
--- a/PostgreSQL/README.md
+++ b/PostgreSQL/README.md
@@ -11,8 +11,8 @@ In order to create your instantiation of the Common Data Model, we recommend fol
 
 3. Load your data into the schema.
 
-4. Execute the script `OMOP CDM postgresql constraints.txt` to add the constraints (primary keys). 
+4. Execute the script `OMOP CDM postgresql indexes required.txt` to add the minimum set of indexes and primary keys we recommend.
 
-5. Execute the script `OMOP CDM postgresql indexes required.txt` to add the minimum set of indexes and foreign keys we recommend.
+5. Execute the script `OMOP CDM postgresql constraints.txt` to add the constraints (foreign keys). 
 
 Note: you could also apply the constraints and/or the indexes before loading the data, but this will slow down the insertion of the data considerably.


### PR DESCRIPTION
Steps 4 and 5 have to be performed in the reverse order. Namely, the (foreign key) constraints depend on the primary key created in the indexes file. This was probably introduced in the new DDL generator change.

Not sure whether this is also the case for other SQL languages.