### PR TITLE
Bug fix Data Model SQL Server

### DIFF
--- a/Sql Server/OMOP CDM Results sql server.txt
+++ b/Sql Server/OMOP CDM Results sql server.txt
@@ -55,7 +55,7 @@ CREATE TABLE cohort
 
 --HINT DISTRIBUTE ON RANDOM
 CREATE TABLE cohort_definition (
-  cohort_definition_id				    INTEGER			  NOT NULL,
+  cohort_definition_id				    BIGINT			  NOT NULL,
   cohort_definition_name			    VARCHAR(255)	NOT NULL,
   cohort_definition_description		VARCHAR(MAX)	NULL,
   definition_type_concept_id		  INTEGER			  NOT NULL,
@@ -82,7 +82,6 @@ ALTER TABLE cohort_definition ADD CONSTRAINT fpk_subject_concept FOREIGN KEY (su
 
 
 ALTER TABLE cohort ADD CONSTRAINT fpk_cohort_definition FOREIGN KEY (cohort_definition_id)  REFERENCES cohort_definition (cohort_definition_id);
-
 
 
 

--- a/Sql Server/OMOP CDM sql server constraints.txt
+++ b/Sql Server/OMOP CDM sql server constraints.txt
@@ -84,9 +84,9 @@ ALTER TABLE relationship ADD CONSTRAINT fpk_relationship_concept FOREIGN KEY (re
 ALTER TABLE relationship ADD CONSTRAINT fpk_relationship_reverse FOREIGN KEY (reverse_relationship_id)  REFERENCES relationship (relationship_id);
 
 
-ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept FOREIGN KEY (concept_id)  REFERENCES concept (concept_id);
+ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept_1 FOREIGN KEY (concept_id)  REFERENCES concept (concept_id);
 
-ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept FOREIGN KEY (language_concept_id)  REFERENCES concept (concept_id);
+ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept_2 FOREIGN KEY (language_concept_id)  REFERENCES concept (concept_id);
 
 
 ALTER TABLE concept_ancestor ADD CONSTRAINT fpk_concept_ancestor_concept_1 FOREIGN KEY (ancestor_concept_id)  REFERENCES concept (concept_id);
@@ -167,13 +167,13 @@ ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_site_concept FOREIGN KEY (anato
 ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_status_concept FOREIGN KEY (disease_status_concept_id)  REFERENCES concept (concept_id);
 
 
-ALTER TABLE death ADD CONSTRAINT fpk_death_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+/*ALTER TABLE death ADD CONSTRAINT fpk_death_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
 
 ALTER TABLE death ADD CONSTRAINT fpk_death_type_concept FOREIGN KEY (death_type_concept_id)  REFERENCES concept (concept_id);
 
 ALTER TABLE death ADD CONSTRAINT fpk_death_cause_concept FOREIGN KEY (cause_concept_id)  REFERENCES concept (concept_id);
 
-ALTER TABLE death ADD CONSTRAINT fpk_death_cause_concept_s FOREIGN KEY (cause_source_concept_id)  REFERENCES concept (concept_id);
+ALTER TABLE death ADD CONSTRAINT fpk_death_cause_concept_s FOREIGN KEY (cause_source_concept_id)  REFERENCES concept (concept_id);*/
 
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
@@ -188,7 +188,7 @@ ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_care_site FOREIGN KEY (car
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_concept_s FOREIGN KEY (visit_source_concept_id)  REFERENCES concept (concept_id);
 
-ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_admitting_s FOREIGN KEY (admitting_source_concept_id) REFERENCES concept (concept_id);
+ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_admitting_s FOREIGN KEY (admitted_from_concept_id) REFERENCES concept (concept_id);
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_discharge FOREIGN KEY (discharge_to_concept_id) REFERENCES concept (concept_id);
 
@@ -207,7 +207,7 @@ ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_care_site FOREIGN KEY (care
 
 ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_discharge FOREIGN KEY (discharge_to_concept_id) REFERENCES concept (concept_id);
 
-ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_admitting_s FOREIGN KEY (admitting_source_concept_id) REFERENCES concept (concept_id);
+ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_admitting_s FOREIGN KEY (admitted_from_concept_id) REFERENCES concept (concept_id);
 
 ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_concept_s FOREIGN KEY (visit_detail_source_concept_id)  REFERENCES concept (concept_id);
 
@@ -370,11 +370,11 @@ ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_source FOREIGN KEY (survey_
 
 ALTER TABLE survey_conduct ADD CONSTRAINT fpk_validation FOREIGN KEY (validated_survey_concept_id) REFERENCES concept (concept_id);
 
-ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_visit FOREIGN KEY (visit_occurrence_id) REFERENCES visit (visit_occurrence_id);
+ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_visit FOREIGN KEY (visit_occurrence_id) REFERENCES visit_occurrence (visit_occurrence_id);
 
 ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_v_detail FOREIGN KEY (visit_detail_id) REFERENCES visit_detail (visit_detail_id);
 
-ALTER TABLE survey_conduct ADD CONSTRAINT fpk_response_visit FOREIGN KEY (response_to_visit_occurrence_id) REFERENCES visit (visit_occurrence_id);
+ALTER TABLE survey_conduct ADD CONSTRAINT fpk_response_visit FOREIGN KEY (visit_occurrence_id) REFERENCES visit_occurrence (visit_occurrence_id);
 
 
 ALTER TABLE fact_relationship ADD CONSTRAINT fpk_fact_domain_1 FOREIGN KEY (domain_concept_id_1)  REFERENCES concept (concept_id);

--- a/Sql Server/OMOP CDM sql server ddl.txt
+++ b/Sql Server/OMOP CDM sql server ddl.txt
@@ -200,9 +200,9 @@ CREATE TABLE metadata
 )
 ;
 
-INSERT INTO metadata (metadata_concept_id, metadata_type_concept_id, name, value_as_string, value_as_concept_id, metadata_date, metadata_datetime) --Added cdm version record
+/*INSERT INTO metadata (metadata_concept_id, metadata_type_concept_id, name, value_as_string, value_as_concept_id, metadata_date, metadata_datetime) --Added cdm version record
 VALUES (0,0,'CDM Version', '6.0',0,NULL,NULL)
-;
+;*/
 
 
 /************************
@@ -503,7 +503,7 @@ CREATE TABLE observation
   value_as_concept_id			    INTEGER			NULL ,
   qualifier_concept_id			    INTEGER			NULL ,
   unit_concept_id				   	INTEGER			NULL ,
-  provider_id					    INTEGER			NULL ,
+  provider_id					    BIGINT			NULL ,
   visit_occurrence_id			    BIGINT			NULL ,
   visit_detail_id               	BIGINT      	NULL ,
   observation_source_value		  	VARCHAR(50)		NULL ,

--- a/Sql Server/OMOP CDM sql server pk indexes.txt
+++ b/Sql Server/OMOP CDM sql server pk indexes.txt
@@ -101,7 +101,7 @@ ALTER TABLE observation_period ADD CONSTRAINT xpk_observation_period PRIMARY KEY
 
 ALTER TABLE specimen ADD CONSTRAINT xpk_specimen PRIMARY KEY NONCLUSTERED ( specimen_id ) ;
 
-ALTER TABLE death ADD CONSTRAINT xpk_death PRIMARY KEY NONCLUSTERED ( person_id ) ;
+/*ALTER TABLE death ADD CONSTRAINT xpk_death PRIMARY KEY NONCLUSTERED ( person_id ) ;*/
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT xpk_visit_occurrence PRIMARY KEY NONCLUSTERED ( visit_occurrence_id ) ;
 
@@ -191,7 +191,7 @@ CREATE INDEX idx_concept_code ON concept (concept_code ASC);
 CREATE INDEX idx_concept_vocabluary_id ON concept (vocabulary_id ASC);
 CREATE INDEX idx_concept_domain_id ON concept (domain_id ASC);
 CREATE INDEX idx_concept_class_id ON concept (concept_class_id ASC);
-CREATE INDEX idx_concept_id_varchar ON concept (CAST(concept_id AS VARCHAR));
+/*CREATE INDEX idx_concept_id_varchar ON concept (CAST(concept_id AS VARCHAR));*/
 
 CREATE UNIQUE CLUSTERED INDEX idx_vocabulary_vocabulary_id ON vocabulary (vocabulary_id ASC);
 
@@ -242,7 +242,7 @@ CREATE CLUSTERED INDEX idx_observation_period_id ON observation_period (person_i
 CREATE CLUSTERED INDEX idx_specimen_person_id ON specimen (person_id ASC);
 CREATE INDEX idx_specimen_concept_id ON specimen (specimen_concept_id ASC);
 
-CREATE CLUSTERED INDEX idx_death_person_id ON death (person_id ASC);
+/*CREATE CLUSTERED INDEX idx_death_person_id ON death (person_id ASC);*/
 
 CREATE CLUSTERED INDEX idx_visit_person_id ON visit_occurrence (person_id ASC);
 CREATE INDEX idx_visit_concept_id ON visit_occurrence (visit_concept_id ASC);
@@ -325,4 +325,3 @@ CREATE INDEX idx_dose_era_concept_id ON dose_era (drug_concept_id ASC);
 
 CREATE CLUSTERED INDEX idx_condition_era_person_id ON condition_era (person_id ASC);
 CREATE INDEX idx_condition_era_concept_id ON condition_era (condition_concept_id ASC);
-


### PR DESCRIPTION
Fixed:
- Results:
cohort_definition_id type from INTEGER to BIGINT
- Constraints:
fpk_concept_synonym_concept two foreign keys with the same name
commented sql statements that alter death table because not present in the ddl
admitting_source_concept_id rename in admitted_from_concept_id
table visit renamed in visit_occurrence
response_to_visit_occurrence_id renamed in visit_occurrence_id
- PK and INDICES:
commented sql statements that alter death table because not present in the ddl
commented index idx_concept_id_varchar because cast does not work
- DDL
commented INSERT INTO metadata because conflicts with constraints because the inserted FK is not present in concept