### PR TITLE
Simplifying codeToRun (don't accept)

### DIFF
--- a/R/writeConstraints.R
+++ b/R/writeConstraints.R
@@ -22,6 +22,25 @@
 #' @param sqlFilename The name of the file that should be rendered and translated to a different dbms.
 #'
 #' @export
+writeConstraintsFromString <- function(targetdialect, cdmVersion, cdmDatabaseSchema, sql) {
+    if(!dir.exists("output")){
+        dir.create("output")
+    }
+    if(!dir.exists(paste0("output/",targetdialect))){
+        dir.create(paste0("output/",targetdialect))
+    }
+    renderedSql <- render(sql = sql,
+                        tempEmulationSchema = getOption("sqlRenderTempEmulationSchema"),
+                        oracleTempSchema = NULL,
+                        warnOnMissingParameters = FALSE)
+                       ## ...)
+    translatedSql <- translate(sql = renderedSql,
+                            targetDialect = targetdialect,
+                            tempEmulationSchema = getOption("sqlRenderTempEmulationSchema"))
+    SqlRender::writeSql(sql = translatedSql,
+                    targetFile = paste0("output/",targetdialect,"/OMOP CDM ",targetdialect," ", cdmVersion, " constraints.sql"))
+
+}
 
 writeConstraints <- function(targetdialect, cdmVersion, cdmDatabaseSchema, sqlFileName) {
 if(!dir.exists("output")){

--- a/R/writePrimaryKeys.R
+++ b/R/writePrimaryKeys.R
@@ -23,6 +23,27 @@
 #'
 #' @export
 
+writePrimaryKeysFromString <- function(targetdialect, cdmVersion, cdmDatabaseSchema, sql) {
+  if(!dir.exists("output")){
+    dir.create("output")
+  }
+
+  if(!dir.exists(paste0("output/",targetdialect))){
+    dir.create(paste0("output/",targetdialect))
+  }
+
+  renderedSql <- render(sql = sql,
+                        tempEmulationSchema = getOption("sqlRenderTempEmulationSchema"),
+                        oracleTempSchema = NULL,
+                        warnOnMissingParameters = FALSE)
+  translatedSql <- translate(sql = renderedSql,
+                            targetDialect = targetdialect,
+                            tempEmulationSchema = getOption("sqlRenderTempEmulationSchema"))
+  SqlRender::writeSql(sql = translatedSql,
+                      targetFile = paste0("output/",targetdialect,"/OMOP CDM ",targetdialect, " ", cdmVersion, " primary keys.sql" ))
+
+}
+
 writePrimaryKeys <- function(targetdialect, cdmVersion, cdmDatabaseSchema, sqlFilename) {
   if(!dir.exists("output")){
     dir.create("output")

--- a/extras/codeToRun.R
+++ b/extras/codeToRun.R
@@ -1,238 +1,190 @@
-#This script is meant to create the OMOP Common Data Model DDLs for each dialect as well as the pdf of the documentation.
 
-# Step 1-2 from README: Create new csv files "..._Field_Level.csv" and "..._Table_Level.csv" in inst/csv for the new version and make changes to the files reflecting
-# the new CDM versions. Set the below variable to indicate the version of the cdm you are creating. This will be used for the name of the pdf so, for
-# example, write v5.3 as v5_3.
+
+# CommonDataModel/extras/codeToRun.R
+# 
+# For each of a bunch of SQL dialects, this script reads a pair of metadata CSV files 
+# and generates  a world of DDL from them. Files are generated for table DDL,
+# primary key DDL and foreign key DDL.
+# It assumes the current directory is the top of the git repo. 
+# The CSV files are in inst/csv and start with OMOP_CDM.
+# The resulting dialect-specific files are deposited into the output directory
+# with subdirectories for each dialect.
+#
+# RUNNING:
+# From a command shell with the current directory as the top of the git repo, run this as follows:
+# shell> Rscript extras/codeToRun.R
+#
+# ISSUES/TODO:
+#   Working in test-mode in a git repository, I wanted to avoid the need for
+#   creating a package as part of running this. In this version, I directly 
+#   source the R code and read files without concern of package location.
+#
+#   I haven't gotten the documentation generation to work.
+#
+#   The CSV files indicate the version with a string like v6.0, and the output SQL/DDL files write it like V6_0.
+#
+#   Automate the tests from this script. Fail obviously if they don't pass. To that, this code doesn't
+#   write the first three (sql server, oracle, postgresql) dialects back into inst/sql/. The tests might
+#   expect them there.
+#
+# MODS
+#   I got clever with a little dataframe of metadata and looped over it to reduce
+#   the amount of duplicated code.
+#
+#   I added functions to the writeDDL, writePK and writeConstraints files that directly
+#   take the strings that come out of the createXXXFromFile functions. This avoids writing
+#   and reading back that data from files, and so avoid the question of where the are, as
+#   well as the package build invovled in putting them. This makes the CSV files drive everything
+#   as the SQL Server version of the DDL isn't kept in the package, but generated.
+#
+#   Perhaps the *BIGGEST DEAL* is that this code works from a git mindset, not a package mindset.
+#   Practically that means the CSV and DDL files aren't accessed by way of the package location, 
+#   and the R files are sourced rather than brought in from a library. This helps two different
+#   processes. 
+#   The first is modifying the R scripts: you can just re-run without having to build
+#   a package. I haven't built packages from within R studio. It's a non-issue if that's a piece
+#   of cake to do there.
+#   The second is for generating the files and ultimately testing. I want to be able to run a script
+#   and go from a freshly pulled git repo and CSV files to generated, tested, documented and loaded
+#   DDL from a script. I don't want to depend on RStudio or manual steps, maybe even the complexity
+#   of buidling a package to get there.  
+#
+# MORE TODO
+#   Consider eventually removing the SQL Server version of the DDL from the project and 
+#   fully promote the CSV files as the single source of truth: It all gets generated from them.
+#
+#   The formal R package has value as a way of getting from install.packages("CommonDataModel") to 
+#   an installed data model in one step, and I haven't fully integrated the two ideas.
+
+
+
+
+if (!require("SqlRender")) { install.packages("SqlRender") }
+library(SqlRender)
+if (!require("pagedown")) { install.packages("pagedown") }
+library(pagedown)
+if (!require("kableExtra")) { install.packages("kableExtra") }
+library(kableExtra)
+
+if (TRUE) {
+    #WikiParser.R
+    source("R/createDdlFromFile.R")
+    source("R/createFkFromFile.R")
+    source("R/createPkFromFile.R")
+    source("R/downloadCurrentDdl.R")
+    source("R/writeConstraints.R")
+    source("R/writeDDL.R")
+    source("R/writeIndex.R")
+    source("R/writePrimaryKeys.R")
+} else {
+    if (!require("CdmDdlBase")) { install.packages("CdmDdlBase") }
+    library("CdmDdlBase")
+}
+
 
   cdmVersion <- "v6_0"
-
-# Step 3: After creating the csv files for the new version, create the sql server DDL from the file
-
-    s <- CdmDdlBase::createDdlFromFile(cdmTableCsvLoc = "inst/csv/OMOP_CDMv6.0_Table_Level.csv",
-                           cdmFieldCsvLoc = "inst/csv/OMOP_CDMv6.0_Field_Level.csv")
-
-  # Step 3.1: Create the primary key constraints for the new version
-
-    p <- CdmDdlBase::createPkFromFile(cdmVersionNum = cdmVersion,
-                                      cdmFieldCsvLoc = "inst/csv/OMOP_CDMv6.0_Field_Level.csv")
-
-  # Step 3.2: Create the foreign key constraints for the new version
-
-    f <- CdmDdlBase::createFkFromFile(cdmVersionNum = cdmVersion,
-                                      cdmFieldCsvLoc = "inst/csv/OMOP_CDMv6.0_Field_Level.csv")
-# At this point you should rebuild the package
-
-# Step 4: Run the following code to render the DDLs for each dialect. These will be used for testing on the ohdsi servers which is why the cdmDatabaseSchema is specified.
-
-writeDDL(targetdialect = "oracle",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "OHDSI",
-         cleanUpScript = F) #oracle syntax for removing tables is weird, set this to F and make any changes to the raw file
-
-writeDDL(targetdialect = "postgresql",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "ohdsi",
-         cleanUpScript = F) #This needs to be updated manually right now
-
-writeDDL(targetdialect = "sql server",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "ohdsi.dbo",
-         cleanUpScript = F) #This needs to be updated manually right now
-
-# Step 5: Run the following code to render the primary key constraints for Oracle, Postgres, and Sql Server
-
-writePrimaryKeys(targetdialect = "oracle",
-                 cdmVersion = cdmVersion,
-                 sqlFilename = paste0("OMOP CDM pk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 cdmDatabaseSchema = "OHDSI")
+  filePrefix <- "OMOP CDM "
+  fileVersion <- "v6.0"
 
 
-writePrimaryKeys(targetdialect = "postgresql",
-                 cdmVersion = cdmVersion,
-                 sqlFilename = paste0("OMOP CDM pk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 cdmDatabaseSchema = "ohdsi")
+# Create the sql server DDL from the file
+    ddl <- createDdlFromFile(cdmTableCsvLoc = paste0("inst/csv/OMOP_CDM", fileVersion, "_Table_Level.csv"),
+                                   outputFile     = paste0(filePrefix, "ddl ", cdmVersion, ".sql"),
+                                   cdmFieldCsvLoc = paste0("inst/csv/OMOP_CDM", fileVersion, "_Field_Level.csv"))
+    pk <- createPkFromFile(cdmVersionNum = cdmVersion,
+                                  outputFile    = paste0(filePrefix, "pk ", cdmVersion, ".sql"),
+                                  cdmFieldCsvLoc = paste0("inst/csv/OMOP_CDM", fileVersion, "_Field_Level.csv"))
+    fk <- createFkFromFile(cdmVersionNum = cdmVersion,
+                                  outputFile    = paste0(filePrefix, "fk ", cdmVersion, ".sql"),
+                                  cdmFieldCsvLoc = paste0("inst/csv/OMOP_CDM", fileVersion, "_Field_Level.csv"))
 
+    # No index files?
 
-writePrimaryKeys(targetdialect = "sql server",
-                 cdmVersion = cdmVersion,
-                 sqlFilename = paste0("OMOP CDM pk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 cdmDatabaseSchema = "ohdsi.dbo")
+# NO package rebuild required.
 
-# Step 6: Run the following code to render the foreign key constraints for Oracle, Postgres, and Sql Server
+# Render the DDLs for the first three dialects with specific schema names for testing.
+    id <- 1:8
+    dialect <- c("oracle", "postgresql", "sql server", "bigquery", "impala", "netezza", "pdw", "redshift" )
+    schema  <- c("OHDSI",  "ohdsi",      "ohdsi.dbo", "@cdmDtabaseSchema", 
+                 "@cdmDatabaseSchema", "@cdmDatabaseSchema", "@cdmDatabaseSchema", "@cdmDatabaseSchema")
+    schema2 <- c("@cdmDatabaseSchema", "@cdmDatabaseSchema", "@cdmDtabaseSchema" , "@cdmDatabaseSchema", 
+                 "@cdmDatabaseSchema", "@cdmDatabaseSchema", "@cdmDatabaseSchema", "@cdmDatabaseSchema")
+    metadf <- data.frame(id, dialect, schema, schema2)
+    for (i in 1:3) {
+        writeDdlFromString(
+            targetdialect = metadf[id==i, 'dialect'],
+            cdmVersion = cdmVersion,
+            cdmDatabaseSchema = metadf[id==i, 'schema'],
+            sql = (paste0(ddl, collapse='')),
+            cleanUpScript = FALSE) #oracle syntax for removing tables is weird, set this to F and make any changes to the raw file
 
-writeConstraints("oracle",
-                 cdmVersion,
-                 sqlFileName = paste0("OMOP CDM fk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 "OHDSI")
+        writePrimaryKeysFromString(
+            targetdialect = metadf[id==i, 'dialect'],
+            cdmVersion = cdmVersion,
+            cdmDatabaseSchema = metadf[id==i, 'schema'],
+            sql = (paste0(pk, collapse='')))
 
-writeConstraints("postgresql",
-                 cdmVersion,
-                 sqlFileName = paste0("OMOP CDM fk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 "ohdsi")
+        writeConstraintsFromString(
+            metadf[id==i, 'dialect'],
+            cdmVersion,
+            cdmDatabaseSchema = metadf[id==i, 'schema'],
+            sql = (paste0(fk, collapse='')))
 
-writeConstraints("sql server",
-                 cdmVersion,
-                 sqlFileName = paste0("OMOP CDM fk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 "ohdsi.dbo")
-
-# Step 7: Run the following code to render the indices for Oracle, Postgres, and Sql Server
-
-writeIndex("oracle", ### NOTE: ORACLE CREATES AUTO INDEXING AND NEED TO UPDATE INST/INDEX FILE TO REPRESENT IT
-           cdmVersion,
-           sqlFilename = "OMOP CDM indices v6_0.sql",
-           "OHDSI")
-
-writeIndex("postgresql",
-           cdmVersion,
-           sqlFilename = "OMOP CDM indices v6_0.sql",
-           "ohdsi")
-
-writeIndex("sql server",
-           cdmVersion,
-           sqlFilename = "OMOP CDM indices v6_0.sql",
-           "ohdsi.dbo")
-
+# Q: where do the index files get created?
+#        writeIndex(
+#           metadf[id==i, 'dialect'],
+#           cdmVersion,
+#           sqlFilename = paste0(filePrefix, "indices ", cdmVersion, ".sql"),
+#           cdmDatabaseSchema = metadf[id==i, 'schema'] )
+    }
 
 ##############################
 # RUN THE TESTTHAT.R TO TEST ORACLE, POSTGRES, AND SQLSERVER
 
 
-# Step 8: After testing the files for Oracle, Postgres, and Sql Server run the following to create the files for all dialects. Oracle
-# Postgres and Sql Server are rewritten to overwrite the cdmDatabaseSchema with a token.
+# Create the files for all dialects. 
+# Oracle,  Postgres and Sql Server are rewritten to overwrite the cdmDatabaseSchema with a token.
+    for (i in 1:8) {
+        writeDdlFromString(
+            targetdialect = metadf[id==i, 'dialect'],
+            cdmVersion = cdmVersion,
+            cdmDatabaseSchema = metadf[id==i, 'schema2'],
+            sql = (paste0(ddl, collapse='')),
+            cleanUpScript = F) #oracle syntax for removing tables is weird, set this to F and make any changes to the raw file
 
-writeDDL(targetdialect = "oracle",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F) #oracle syntax for removing tables is weird, set this to F and make any changes to the raw file
+        writePrimaryKeysFromString(
+            targetdialect = metadf[id==i, 'dialect'],
+            cdmVersion = cdmVersion,
+            cdmDatabaseSchema = metadf[id==i, 'schema2'],
+            sql = (paste0(pk, collapse='')))
 
-writeDDL(targetdialect = "postgresql",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F) #This needs to be updated manually right now
+        writeConstraintsFromString(
+            metadf[id==i, 'dialect'],
+            cdmVersion,
+            cdmDatabaseSchema = metadf[id==i, 'schema2'],
+            sql = (paste0(fk, collapse='')))
 
-writeDDL(targetdialect = "sql server",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F) #This needs to be updated manually right now
-
-writeDDL(targetdialect = "bigquery",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F)
-
-writeDDL(targetdialect = "impala",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F)
-
-writeDDL(targetdialect = "netezza",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F)
-
-writeDDL(targetdialect = "pdw",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F)
-
-writeDDL(targetdialect = "redshift",
-         cdmVersion = cdmVersion,
-         sqlFilename = paste0("OMOP CDM ddl ", cdmVersion, " ", Sys.Date(), ".sql"),
-         cdmDatabaseSchema = "@cdmDatabaseSchema",
-         cleanUpScript = F)
-
-## Write all primary keys
-
-writePrimaryKeys(targetdialect = "oracle",
-                 cdmVersion = cdmVersion,
-                 sqlFilename = paste0("OMOP CDM pk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 cdmDatabaseSchema = "@cdmDatabaseSchema")
+#        writeIndex(
+#           metadf[id==i, 'dialect'],
+#           cdmVersion,
+#           sqlFilename = paste0(filePrefix, "indices ", cdmVersion, ".sql"),
+#           cdmDatabaseSchema = metadf[id==i, 'schema2'] )
+    }
 
 
-writePrimaryKeys(targetdialect = "postgresql",
-                 cdmVersion = cdmVersion,
-                 sqlFilename = paste0("OMOP CDM pk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 cdmDatabaseSchema = "@cdmDatabaseSchema")
+#setwd("C:/Git/Github/CdmDdlBase/rmd")
+#setwd("rmd")
+#rmarkdown::render_site()
+#setwd("..")
 
+# Create the PDF documentation.
+##########pagedown::chrome_print("rmd/cdm531.Rmd") # https://stackoverflow.com/questions/25824795/how-to-combine-two-rmarkdown-rmd-files-into-a-single-output
 
-writePrimaryKeys(targetdialect = "sql server",
-                 cdmVersion = cdmVersion,
-                 sqlFilename = paste0("OMOP CDM pk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 cdmDatabaseSchema = "@cdmDatabaseSchema")
-
-writePrimaryKeys(targetdialect = "netezza",
-                 cdmVersion = cdmVersion,
-                 sqlFilename = paste0("OMOP CDM pk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 cdmDatabaseSchema = "@cdmDatabaseSchema")
-
-## write all foreign key constraints
-
-writeConstraints("oracle",
-                 cdmVersion,
-                 sqlFileName = paste0("OMOP CDM fk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 "@cdmDatabaseSchema")
-
-writeConstraints("postgresql",
-                 cdmVersion,
-                 sqlFileName = paste0("OMOP CDM fk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 "@cdmDatabaseSchema")
-
-writeConstraints("sql server",
-                 cdmVersion,
-                 sqlFileName = paste0("OMOP CDM fk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 "@cdmDatabaseSchema")
-
-writeConstraints("pdw",
-                 cdmVersion,
-                 sqlFileName = paste0("OMOP CDM fk ", cdmVersion, " ", Sys.Date(), ".sql"),
-                 "@cdmDatabaseSchema")
-
-## write all indices
-
-writeIndex("oracle", ### NOTE: ORACLE CREATES AUTO INDEXING AND NEED TO UPDATE INST/INDEX FILE TO REPRESENT IT
-           cdmVersion,
-           sqlFilename = "OMOP CDM indices v5_3_1.sql",
-           "@cdmDatabaseSchema")
-
-writeIndex("postgresql",
-           cdmVersion,
-           sqlFilename = "OMOP CDM indices v5_3_1.sql",
-           "@cdmDatabaseSchema")
-
-writeIndex("sql server",
-           cdmVersion,
-           sqlFilename = "OMOP CDM indices v5_3_1.sql",
-           "@cdmDatabaseSchema")
-
-writeIndex("pdw",
-           cdmVersion,
-           sqlFilename = "OMOP CDM indices v5_3_1.sql",
-           "@cdmDatabaseSchema")
-
-
-#############
-# BE SURE TO RUN THE EXTRAS/SITEMAINTENANCE.R BEFORE CREATING THE PDF
-
-# step 9: Run the following code to create the pdf documentation. It will be written to the reports folder. Use knit with pagedown
-pagedown::chrome_print("rmd/cdm531.Rmd") # create a comprehensive rmd with background, conventions, etc like https://stackoverflow.com/questions/25824795/how-to-combine-two-rmarkdown-rmd-files-into-a-single-output
-
-# Step 10: After updating any of the .Rmd files, rendering the site following directions in SiteMaintenance.R, then move the files to the CommonDataModel directory
-
-newdir <- "C:/Git/Github/CommonDataModel/docs"
-currentdir <- paste0(getwd(),"/docs/")
-
-
-file.copy(currentdir, newdir, recursive = TRUE, overwrite = TRUE)
+# Move the files to the CommonDataModel directory
+#newdir <- "C:/Git/Github/CommonDataModel/docs"
+#newdir <- "docs"
+#currentdir <- paste0(getwd(),"/docs/")
+#file.copy(currentdir, newdir, recursive = TRUE, overwrite = TRUE)
 
 
 


### PR DESCRIPTION
Here's some WIP  you might be interested in. Please reject this PR, it's just for show.

I basically did two things here. First, i created some metadata, metadf, to drive the processing, so I loop over it and simplify the code a bit.

More interestingly is a tweak that uses the strings that get returned from the first three createXXXFromFile functions and passes it on to the writeXXX functions instead of going by way of a file and package re-build. The idea is to make it more scriptable to build and test.

Still need to consider the package as something you install in R and call a function and have it install the data model, as I believe Martijn and Frank envision things.

