### PR TITLE
Fixed condition_era column names

### DIFF
--- a/PostgreSQL/OMOP CDM postgresql ddl.txt
+++ b/PostgreSQL/OMOP CDM postgresql ddl.txt
@@ -746,8 +746,8 @@ CREATE TABLE condition_era
   condition_era_id					BIGINT			NOT NULL ,
   person_id							BIGINT			NOT NULL ,
   condition_concept_id				INTEGER			NOT NULL ,
-  condition_era_start_datetime		TIMESTAMP		NOT NULL ,
-  condition_era_end_datetime		TIMESTAMP		NOT NULL ,
+  condition_era_start_date		TIMESTAMP		NOT NULL ,
+  condition_era_end_date		TIMESTAMP		NOT NULL ,
   condition_occurrence_count		INTEGER			NULL
 )
 ;


### PR DESCRIPTION
condition_era_start_datetime and condition_era_end_datetime would lead to an error when running runCohortDiagnostics.

Suggested to change to condition_era_start_date and condition_era_end_date to match the codes.

and also to match documentation on the CDM

https://ohdsi.github.io/CommonDataModel/cdm531.html#CONDITION_ERA