### PR TITLE
Correct mispelling in CDM 5.4 Documentation (Observation Period)

### DIFF
--- a/docs/cdm54.html
+++ b/docs/cdm54.html
@@ -1266,7 +1266,7 @@ occurrence or the first high quality occurrence of a Clinical Event
 (Condition, Drug, Procedure, Device, Measurement, Visit) is defined as
 the start of the OBSERVATION_PERIOD record, and the end date of the last
 occurrence of last high quality occurrence of a Clinical Event, or the
-end of the database period becomes the end of the OBSERVATOIN_PERIOD for
+end of the database period becomes the end of the OBSERVATION_PERIOD for
 each Person. If a Person only has a single Clinical Event the
 OBSERVATION_PERIOD record can be as short as one day. Depending on these
 definitions it is possible that Clinical Events fall outside the time


### PR DESCRIPTION
This corrects a mispelling in the documentation: 
"OBSERVATION_PERIOD" was mispelled as "OBSERVATOIN_PERIOD" on https://ohdsi.github.io/CommonDataModel/cdm54.html#observation_period. 