### PR TITLE
Fixed typos/grammar and a missing link in dataModelConventions.html

### DIFF
--- a/docs/dataModelConventions.html
+++ b/docs/dataModelConventions.html
@@ -628,8 +628,9 @@ source vocabulary.</li>
 may appear in CDM tables in all *_concept_id fields, whereas
 Classification Concepts (‘C’) should not appear in the CDM data, but
 participate in the construction of the CONCEPT_ANCESTOR table and can be
-used to identify Descendants that may appear in the data. See
-CONCEPT_ANCESTOR table. Non-standard Concepts can only appear in
+used to identify Descendants that may appear in the data. See <a
+href="https://ohdsi.github.io/CommonDataModel/cdm54.html#concept_ancestor">CONCEPT_ANCESTOR</a>
+table. Non-standard Concepts can only appear in
 *_source_concept_id fields and are not used in <a
 href="https://ohdsi.github.io/CommonDataModel/cdm54.html#concept_ancestor">CONCEPT_ANCESTOR</a>
 table. Please refer to the Standardized Vocabularies specifications for

--- a/docs/download.html
+++ b/docs/download.html
@@ -508,8 +508,8 @@ ddl, primary key constraints, indices, and foreign key constraints. In
 contrast, the redshift folder only has a ddl.</p>
 <p>These sql scripts have been fully tested on Oracle, Sql Server, and
 Postgresql and the rest are generated using the <a
-href="https://ohdsi.github.io/SqlRender/">SqlRender package</a>. If run
-into any problems please let us know by creating an issue on our
+href="https://ohdsi.github.io/SqlRender/">SqlRender package</a>. If you
+run into any problems please let us know by creating an issue on our
 github.</p>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -511,7 +511,7 @@ potentially affected workgroups. The <a
 href="http://ohdsi.github.io/CommonDataModel/cdm54Changes.html">final
 changes</a> were then delivered to the Community through a new R package
 designed to dynamically generate the DDLs and documentation for all
-supported SQL dialects. Looking for an entity-relationshop diagram?
+supported SQL dialects. Looking for an entity-relationship diagram?
 Click <a
 href="http://ohdsi.github.io/CommonDataModel/cdm54erd.html">here</a>!</p>
 <ul>


### PR DESCRIPTION
Fixed a small typo/grammatical mistake and added a missing hyperlink on "CONCEPT_ANCESTORS" in `dataModelConventions.html`