### PR TITLE
Missing quotes for text element containing a comma.

### DIFF
--- a/inst/csv/OMOP_CDMv5.4_Field_Level.csv
+++ b/inst/csv/OMOP_CDMv5.4_Field_Level.csv
@@ -396,7 +396,7 @@ cdm_source,cdm_source_name,Yes,varchar(255),The name of the CDM instance.,NA,No,
 cdm_source,cdm_source_abbreviation,Yes,varchar(25),The abbreviation of the CDM instance.,NA,No,No,NA,NA,NA,NA,NA
 cdm_source,cdm_holder,Yes,varchar(255),The holder of the CDM instance.,NA,No,No,NA,NA,NA,NA,NA
 cdm_source,source_description,No,varchar(MAX),The description of the CDM instance.,NA,No,No,NA,NA,NA,NA,NA
-cdm_source,source_documentation_reference,No,varchar(255),Refers to a publication or web resource describing the source data, e.g. a data dictionary.,NA,No,No,NA,NA,NA,NA,NA
+cdm_source,source_documentation_reference,No,varchar(255),"Refers to a publication or web resource describing the source data, e.g. a data dictionary.",NA,No,No,NA,NA,NA,NA,NA
 cdm_source,cdm_etl_reference,No,varchar(255),NA,Version of the ETL script used. e.g. link to the Git release,No,No,NA,NA,NA,NA,NA
 cdm_source,source_release_date,Yes,date,The date the data was extracted from the source system. In some systems that is the same as the date the ETL was run. Typically the latest even date in the source is on the source_release_date.,NA,No,No,NA,NA,NA,NA,NA
 cdm_source,cdm_release_date,Yes,date,The date the ETL script was completed. Typically this is after the source_release_date.,NA,No,No,NA,NA,NA,NA,NA
@@ -549,3 +549,4 @@ cohort_definition,definition_type_concept_id,Yes,integer,Type defining what kind
 cohort_definition,cohort_definition_syntax,No,varchar(MAX),Syntax or code to operationalize the Cohort Definition.,NA,No,No,NA,NA,NA,NA,NA
 cohort_definition,subject_concept_id,Yes,integer,"This field contains a Concept that represents the domain of the subjects that are members of the cohort (e.g., Person, Provider, Visit).",NA,No,Yes,CONCEPT,CONCEPT_ID,NA,NA,NA
 cohort_definition,cohort_initiation_date,No,date,A date to indicate when the Cohort was initiated in the COHORT table.,NA,No,No,NA,NA,NA,NA,NA
+


### PR DESCRIPTION
Without the quote, CSV parsing results in an unwanted additional element for that row.