### PR TITLE
fix(tests): use correct env var name for PostgreSQL server

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,6 +1,6 @@
 testDatabases <- c("postgresql")
 
-if (Sys.getenv("CDM5_POSTGRESQL_SERVER") != "") {
+if (Sys.getenv("CDMDDLBASE_POSTGRESQL_SERVER") != "") {
   library(DatabaseConnector)
 
   if (dir.exists(Sys.getenv("DATABASECONNECTOR_JAR_FOLDER"))) {

--- a/tests/testthat/test-executeDdl.R
+++ b/tests/testthat/test-executeDdl.R
@@ -1,7 +1,7 @@
 
 # connection based tests required environment variables be configured
 test_that("CommonDataModel Execution Test", {
-  if (Sys.getenv("CDM5_POSTGRESQL_SERVER") != "") {
+  if (Sys.getenv("CDMDDLBASE_POSTGRESQL_SERVER") != "") {
     test_that("getConnectionDetails works", {
       for (dbms in testDatabases) {
         expect_s3_class(getConnectionDetails(dbms), "ConnectionDetails")


### PR DESCRIPTION
The skip guard in `setup.R` and `test-executeDdl.R` checks `CDM5_POSTGRESQL_SERVER`, but all actual connection details use `CDMDDLBASE_POSTGRESQL_SERVER`. This mismatch means tests try to run in environments where `CDM5_POSTGRESQL_SERVER` is set (common in OHDSI CI) but `CDMDDLBASE_POSTGRESQL_SERVER` is not, leading to failures instead of a clean skip.

Changed both occurrences to `CDMDDLBASE_POSTGRESQL_SERVER` so the guard matches the actual variable that `getConnectionDetails()` reads.

Closes #719