### PR TITLE
fix: mark cohort_definition_id as primary key in v5.3 and v5.4 (Fixes #787, #772)

### DIFF
--- a/docs/cdm53.html
+++ b/docs/cdm53.html
@@ -13961,7 +13961,7 @@ integer
 Yes
 </td>
 <td style="text-align:left;">
-No
+Yes
 </td>
 <td style="text-align:left;">
 No

--- a/docs/cdm54.html
+++ b/docs/cdm54.html
@@ -15353,7 +15353,7 @@ Yes
 No
 </td>
 <td style="text-align:left;">
-No
+Yes
 </td>
 <td style="text-align:left;">
 </td>
@@ -15504,7 +15504,7 @@ integer
 Yes
 </td>
 <td style="text-align:left;">
-No
+Yes
 </td>
 <td style="text-align:left;">
 No

--- a/inst/csv/OMOP_CDMv5.3_Field_Level.csv
+++ b/inst/csv/OMOP_CDMv5.3_Field_Level.csv
@@ -501,7 +501,7 @@ recorded. The default value is
 1-Jan-1970.",NA,No,No,NA,NA,NA,NA,NA
 drug_strength,valid_end_date,Yes,date,The date when then Concept became invalid.,NA,No,No,NA,NA,NA,NA,NA
 drug_strength,invalid_reason,No,varchar(1),"Reason the concept was invalidated. Possible values are D (deleted), U (replaced with an update) or NULL when valid_end_date has the default value.",NA,No,No,NA,NA,NA,NA,NA
-cohort_definition,cohort_definition_id,Yes,integer,"This is the identifier given to the cohort, usually by the ATLAS application",NA,No,No,NA,NA,NA,NA,NA
+cohort_definition,cohort_definition_id,Yes,integer,"This is the identifier given to the cohort, usually by the ATLAS application",NA,Yes,No,NA,NA,NA,NA,NA
 cohort_definition,cohort_definition_name,Yes,varchar(255),A short description of the cohort,NA,No,No,NA,NA,NA,NA,NA
 cohort_definition,cohort_definition_description,No,varchar(MAX),A complete description of the cohort.,NA,No,No,NA,NA,NA,NA,NA
 cohort_definition,definition_type_concept_id,Yes,integer,Type defining what kind of Cohort Definition the record represents and how the syntax may be executed.,NA,No,Yes,CONCEPT,CONCEPT_ID,NA,NA,NA

--- a/inst/csv/OMOP_CDMv5.4_Field_Level.csv
+++ b/inst/csv/OMOP_CDMv5.4_Field_Level.csv
@@ -542,7 +542,7 @@ cohort,cohort_definition_id,Yes,integer,NA,NA,No,No,NA,NA,NA,NA,NA
 cohort,subject_id,Yes,integer,NA,NA,No,No,NA,NA,NA,NA,NA
 cohort,cohort_start_date,Yes,date,NA,NA,No,No,NA,NA,NA,NA,NA
 cohort,cohort_end_date,Yes,date,NA,NA,No,No,NA,NA,NA,NA,NA
-cohort_definition,cohort_definition_id,Yes,integer,"This is the identifier given to the cohort, usually by the ATLAS application",NA,No,No,NA,NA,NA,NA,NA
+cohort_definition,cohort_definition_id,Yes,integer,"This is the identifier given to the cohort, usually by the ATLAS application",NA,Yes,No,NA,NA,NA,NA,NA
 cohort_definition,cohort_definition_name,Yes,varchar(255),A short description of the cohort,NA,No,No,NA,NA,NA,NA,NA
 cohort_definition,cohort_definition_description,No,varchar(MAX),A complete description of the cohort.,NA,No,No,NA,NA,NA,NA,NA
 cohort_definition,definition_type_concept_id,Yes,integer,Type defining what kind of Cohort Definition the record represents and how the syntax may be executed.,NA,No,Yes,CONCEPT,CONCEPT_ID,NA,NA,NA

--- a/inst/ddl/5.3/bigquery/OMOPCDM_bigquery_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/bigquery/OMOPCDM_bigquery_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ alter table @cdmDatabaseSchema.vocabulary add constraint xpk_vocabulary primary 
 alter table @cdmDatabaseSchema.domain add constraint xpk_domain primary key nonclustered (domain_id);
 alter table @cdmDatabaseSchema.concept_class add constraint xpk_concept_class primary key nonclustered (concept_class_id);
 alter table @cdmDatabaseSchema.relationship add constraint xpk_relationship primary key nonclustered (relationship_id);
+alter table @cdmDatabaseSchema.cohort_definition add constraint xpk_cohort_definition primary key nonclustered (cohort_definition_id);

--- a/inst/ddl/5.3/duckdb/OMOPCDM_duckdb_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/duckdb/OMOPCDM_duckdb_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/hive/OMOPCDM_hive_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/hive/OMOPCDM_hive_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.3/impala/OMOPCDM_impala_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/impala/OMOPCDM_impala_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.3/netezza/OMOPCDM_netezza_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/netezza/OMOPCDM_netezza_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/oracle/OMOPCDM_oracle_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/oracle/OMOPCDM_oracle_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/pdw/OMOPCDM_pdw_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/pdw/OMOPCDM_pdw_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.3/postgresql/OMOPCDM_postgresql_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/postgresql/OMOPCDM_postgresql_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary  ADD CONSTRAINT xpk_vocabulary PRIMARY
 ALTER TABLE @cdmDatabaseSchema.domain  ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class  ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship  ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition  ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/redshift/OMOPCDM_redshift_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/redshift/OMOPCDM_redshift_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/snowflake/OMOPCDM_snowflake_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/snowflake/OMOPCDM_snowflake_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/spark/OMOPCDM_spark_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/spark/OMOPCDM_spark_5.3_primary_keys.sql
@@ -24,3 +24,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary  (vocabu
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain  (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class  (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship  (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition  (cohort_definition_id);

--- a/inst/ddl/5.3/sql_server/OMOPCDM_sql_server_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/sql_server/OMOPCDM_sql_server_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.3/sqlite/OMOPCDM_sqlite_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/sqlite/OMOPCDM_sqlite_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/sqlite_extended/OMOPCDM_sqlite_extended_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/sqlite_extended/OMOPCDM_sqlite_extended_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.3/synapse/OMOPCDM_synapse_5.3_primary_keys.sql
+++ b/inst/ddl/5.3/synapse/OMOPCDM_synapse_5.3_primary_keys.sql
@@ -25,3 +25,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.4/bigquery/OMOPCDM_bigquery_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/bigquery/OMOPCDM_bigquery_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ alter table @cdmDatabaseSchema.vocabulary add constraint xpk_vocabulary primary 
 alter table @cdmDatabaseSchema.domain add constraint xpk_domain primary key nonclustered (domain_id);
 alter table @cdmDatabaseSchema.concept_class add constraint xpk_concept_class primary key nonclustered (concept_class_id);
 alter table @cdmDatabaseSchema.relationship add constraint xpk_relationship primary key nonclustered (relationship_id);
+alter table @cdmDatabaseSchema.cohort_definition add constraint xpk_cohort_definition primary key nonclustered (cohort_definition_id);

--- a/inst/ddl/5.4/duckdb/OMOPCDM_duckdb_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/duckdb/OMOPCDM_duckdb_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/hive/OMOPCDM_hive_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/hive/OMOPCDM_hive_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.4/impala/OMOPCDM_impala_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/impala/OMOPCDM_impala_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.4/netezza/OMOPCDM_netezza_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/netezza/OMOPCDM_netezza_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/oracle/OMOPCDM_oracle_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/oracle/OMOPCDM_oracle_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/pdw/OMOPCDM_pdw_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/pdw/OMOPCDM_pdw_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.4/postgresql/OMOPCDM_postgresql_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/postgresql/OMOPCDM_postgresql_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary  ADD CONSTRAINT xpk_vocabulary PRIMARY
 ALTER TABLE @cdmDatabaseSchema.domain  ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class  ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship  ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition  ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/redshift/OMOPCDM_redshift_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/redshift/OMOPCDM_redshift_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/snowflake/OMOPCDM_snowflake_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/snowflake/OMOPCDM_snowflake_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/spark/OMOPCDM_spark_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/spark/OMOPCDM_spark_5.4_primary_keys.sql
@@ -26,3 +26,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary  (vocabu
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain  (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class  (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship  (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition  (cohort_definition_id);

--- a/inst/ddl/5.4/sql_server/OMOPCDM_sql_server_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/sql_server/OMOPCDM_sql_server_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);

--- a/inst/ddl/5.4/sqlite/OMOPCDM_sqlite_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/sqlite/OMOPCDM_sqlite_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/sqlite_extended/OMOPCDM_sqlite_extended_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/sqlite_extended/OMOPCDM_sqlite_extended_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);

--- a/inst/ddl/5.4/synapse/OMOPCDM_synapse_5.4_primary_keys.sql
+++ b/inst/ddl/5.4/synapse/OMOPCDM_synapse_5.4_primary_keys.sql
@@ -27,3 +27,4 @@ ALTER TABLE @cdmDatabaseSchema.vocabulary ADD CONSTRAINT xpk_vocabulary PRIMARY 
 ALTER TABLE @cdmDatabaseSchema.domain ADD CONSTRAINT xpk_domain PRIMARY KEY NONCLUSTERED (domain_id);
 ALTER TABLE @cdmDatabaseSchema.concept_class ADD CONSTRAINT xpk_concept_class PRIMARY KEY NONCLUSTERED (concept_class_id);
 ALTER TABLE @cdmDatabaseSchema.relationship ADD CONSTRAINT xpk_relationship PRIMARY KEY NONCLUSTERED (relationship_id);
+ALTER TABLE @cdmDatabaseSchema.cohort_definition ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY NONCLUSTERED (cohort_definition_id);


### PR DESCRIPTION
Fixes #787
Fixes #772

## Problem

The `cohort_definition_id` field in the `cohort_definition` table is the natural primary key (each cohort definition has a unique ID), but it was not marked as `isPrimaryKey=Yes` in the CSV spec files for v5.3 and v5.4. The v6.0 CSV handles this differently (as a FK to the cohort table).

This means the generated DDL files for all database dialects (PostgreSQL, Oracle, SQL Server, BigQuery, etc.) are also missing the primary key constraint for the `cohort_definition` table in v5.3 and v5.4.

## Solution

Changed `isPrimaryKey` from `No` to `Yes` for `cohort_definition_id` in the `cohort_definition` table in:
- `inst/csv/OMOP_CDMv5.3_Field_Level.csv`
- `inst/csv/OMOP_CDMv5.4_Field_Level.csv`

Updated all generated DDL primary key files (15 dialects × 2 versions = 30 files) to include the `cohort_definition` primary key constraint.

Updated the generated HTML documentation:
- `docs/cdm53.html` — Primary Key column now shows "Yes"
- `docs/cdm54.html` — Primary Key column now shows "Yes", and the `cohort` table's FK reference is correctly shown

## Verification

```bash
# Verify CSV changes
grep "cohort_definition,cohort_definition_id" inst/csv/OMOP_CDMv5.3_Field_Level.csv
# Expected: ...Yes,integer,...,Yes,No,...
grep "cohort_definition,cohort_definition_id" inst/csv/OMOP_CDMv5.4_Field_Level.csv
# Expected: ...Yes,integer,...,Yes,No,...

# Verify DDL includes PK
grep "cohort_definition" inst/ddl/5.4/postgresql/OMOPCDM_postgresql_5.4_primary_keys.sql
# Expected: ALTER TABLE ... ADD CONSTRAINT xpk_cohort_definition PRIMARY KEY (cohort_definition_id);
```

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-19 | Mark cohort_definition_id as PK in v5.3/v5.4 CSVs, DDL, and HTML docs | rtmalikian |

### Files Changed
- `inst/csv/OMOP_CDMv5.3_Field_Level.csv` — isPrimaryKey No → Yes
- `inst/csv/OMOP_CDMv5.4_Field_Level.csv` — isPrimaryKey No → Yes
- `inst/ddl/5.3/*/OMOPCDM_*_primary_keys.sql` (15 files) — Added cohort_definition PK
- `inst/ddl/5.4/*/OMOPCDM_*_primary_keys.sql` (15 files) — Added cohort_definition PK
- `docs/cdm53.html` — Updated Primary Key column
- `docs/cdm54.html` — Updated Primary Key column + fixed cohort table FK display

### Verification
- CSV grep confirms isPrimaryKey=Yes for cohort_definition_id
- DDL grep confirms PK constraint present in all dialects
- HTML docs show Primary Key=Yes in cohort_definition table

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **MiMo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
