### PR TITLE
Fix R-CMD-check: update deprecated actions and retired ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/R_CMD_check.yaml
+++ b/.github/workflows/R_CMD_check.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-22.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"}
           - {os: windows-latest, r: 'release'}  # Does not appear to have Java 32-bit, hence the --no-multiarch
 
     env:
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -79,7 +79,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "22.04"))')
 
       - name: Install libssh
         if: runner.os == 'Linux'
@@ -111,14 +111,14 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
 
       - name: Upload source package
         if: success() && runner.os == 'macOS' && github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: package_tarball
           path: check/*.tar.gz


### PR DESCRIPTION
## Summary

Every R-CMD-check run currently fails during job setup, before any R code executes, because GitHub now automatically rejects deprecated action versions and has retired the ubuntu-20.04 hosted runner:

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v3.3.1` … a deprecated version of `actions/upload-artifact: v2`

([actions/cache notice](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/), [artifact actions notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/), [ubuntu-20.04 retirement](https://github.blog/changelog/2025-04-15-github-actions-ubuntu-20-runner-image-brownout-scheduled/))

## Changes

- `actions/cache` v3.3.1 → v4
- `actions/upload-artifact` v2 → v4 (both uses; artifact names were already unique per job, which v4 requires)
- `ubuntu-20.04` runner → `ubuntu-22.04`, with the RSPM repository (focal → jammy) and `remotes::system_requirements()` lookup updated to match

## Verification

Run on my fork with these changes: https://github.com/PouyanJay/CommonDataModel/actions/runs/29622329863 — jobs now provision and execute (macOS completed successfully) instead of failing in ~4 seconds during setup.

Note: this also affects PR checks — currently every PR to this repo gets a red X from these setup failures regardless of its content (e.g. #794).
